### PR TITLE
Jitted right inverse

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -187,8 +187,6 @@ from warnings import warn
 import numpy as np
 from numpy import linalg, array
 import numba
-from scipy import stats
-
 
 # The blade finding regex for parsing strings of mvs
 _blade_pattern =  "((^|\s)-?\s?\d+(\.\d+)?)\s|(-\s?(\d+((e(\+|-))|\.)?(\d+)?)\^e\d+(\s|$))|((^|\+)\s?(\d+((e(\+|-))|\.)?(\d+)?)\^e\d+(\s|$))"

--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -187,7 +187,7 @@ from warnings import warn
 import numpy as np
 from numpy import linalg, array
 import numba
-
+from scipy import stats
 
 
 # The blade finding regex for parsing strings of mvs
@@ -324,6 +324,54 @@ def get_mult_function(mult_table,n_dims,gradeList,grades_a=None,grades_b=None,fi
                     output[l] += v_val*mult_table_vals[ind]*ov_val
         return output
     return mv_mult
+
+
+@numba.jit
+def grade_obj_func(objin_val, gradeList, threshold):
+    """ returns the modal grade of a multivector """
+    modal_value_count = np.zeros(objin_val.shape)
+    n = 0
+    for g in gradeList:
+        if np.abs(objin_val[n]) > threshold:
+            modal_value_count[g] += 1
+        n += 1
+    return np.argmax(modal_value_count)
+
+
+def grade_obj(objin, threshold=0.0000001):
+    """ returns the modal grade of a multivector """
+    return grade_obj_func(objin.value, objin.layout.gradeList, threshold)
+
+
+def get_right_inverse_function(mult_table, n_dims, gradeList):
+    '''
+    Returns a function that implements the right_inverse
+    '''
+
+    identity = np.zeros((n_dims,))
+    identity[gradeList.index(0)] = 1
+
+    tempAxes = (1,0,2)
+    newB = np.transpose(mult_table, tempAxes)
+
+    non_zero_indices = newB.nonzero()
+    k_list = non_zero_indices[0]
+    l_list = non_zero_indices[1]
+    m_list = non_zero_indices[2]
+    newB_vals = np.array([newB[k, l, m] for k, l, m in np.transpose(non_zero_indices)], dtype=int)
+
+    @numba.njit
+    def rightLaInv_func(value):
+        intermed = np.zeros((n_dims,n_dims))
+        for ind,l in enumerate(l_list):
+            m = m_list[ind]
+            k = k_list[ind]
+            intermed[k, m] += value[l]*newB_vals[ind]
+        sol = linalg.lstsq(intermed, identity)[0]
+        return sol
+    return rightLaInv_func
+
+
 
 
 def _myDot(a, b):
@@ -663,6 +711,7 @@ class Layout(object):
         self.imt_func = get_mult_function(imt,self.gaDims,self.gradeList)
         self.omt_func = get_mult_function(omt,self.gaDims,self.gradeList)
         self.lcmt_func = get_mult_function(lcmt,self.gaDims,self.gradeList)
+        self.rightLaInv_func = get_right_inverse_function(gmt, self.gaDims, self.gradeList)
         self.gmt = gmt
         self.imt = imt
         self.omt = omt
@@ -1593,18 +1642,7 @@ class MultiVector(object):
         M    where M * M  == 1
         rightLaInv() --> MultiVector
         """
-
-        identity = np.zeros((self.layout.gaDims,))
-        identity[self.layout.gradeList.index(0)] = 1
-
-        intermed = _myDot(self.value, self.layout.gmt)
-
-        if abs(linalg.det(intermed)) < _eps:
-            warn('Inverse might be inaccurate')
-            #raise ValueError("multivector has no right-inverse")
-
-        sol = linalg.solve(intermed, identity)
-
+        sol = self.layout.rightLaInv_func(self.value)
         return self._newMV(sol)
 
     def normalInv(self):

--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -365,7 +365,7 @@ def get_right_inverse_function(mult_table, n_dims, gradeList):
             m = m_list[ind]
             k = k_list[ind]
             intermed[k, m] += value[l]*newB_vals[ind]
-        sol = linalg.lstsq(intermed, identity)[0]
+        sol = linalg.solve(intermed, identity)[0]
         return sol
     return rightLaInv_func
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name='clifford',
 	packages=find_packages(),
 	install_requires = [
 		'numpy',
+		'scipy',
 		'numba',
 		'future',
 		],

--- a/test_clifford.py
+++ b/test_clifford.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 from past.builtins import range
 
-from clifford import Cl, randomMV, Frame, get_mult_function, conformalize
+from clifford import Cl, randomMV, Frame, get_mult_function, conformalize, grade_obj
 from clifford.tools import orthoFrames2Verser as of2v
 
 from numpy import exp, float64, testing
@@ -50,6 +50,14 @@ class CliffordTests(unittest.TestCase):
 
 
 class BasicAlgebraTests(unittest.TestCase):
+
+    def test_grade_obj(self):
+        algebras = [Cl(i) for i in [3, 4]] + [conformalize(Cl(3)[0])]
+        for alg in algebras:
+            layout = alg[0]
+            for i in range(len(layout.sig)+1):
+                mv = layout.randomMV()(i)
+                assert i == grade_obj(mv)
 
     def test_sparse_multiply(self):
         algebras = [Cl(i) for i in [3, 4]] + [conformalize(Cl(3)[0])]


### PR DESCRIPTION
This branch takes a look at the right inverse function which was previously implemented via the _myDot function. 
This PR replaces it with a jitted function that uses the sparsity of the gmt table resulting in significant speed up.
https://gist.github.com/hugohadfield/50561a0b01123e3f6e9e41f948398ee2

Additionally it adds a function that returns the modal grade of the non zero elements in a multivector. This is slightly accidentally snuck in, happy to seperate it into a different PR if that would be better.