### PR TITLE
Remove large sparse matrices from layout object

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -203,23 +203,6 @@ def get_longest_string(string_array):
     return max(string_array,key=len)
 
 
-def _sign(seq, orig):
-    """Determine {even,odd}-ness of permutation seq or orig.
-
-    Returns 1 if even; -1 if odd.
-    """
-
-    sign = 1
-    seq = list(seq)
-
-    for i in range(len(seq)):
-            if seq[i] != orig[i]:
-                j = seq.index(orig[i])
-                sign = -sign
-                seq[i], seq[j] = seq[j], seq[i]
-    return sign
-
-
 def get_adjoint_function(gradeList):
     '''
     This function returns a fast jitted adjoint function
@@ -319,28 +302,6 @@ def grade_obj(objin, threshold=0.0000001):
     Returns the modal grade of a multivector
     '''
     return grade_obj_func(objin.value, objin.layout.gradeList, threshold)
-
-
-def _myDot(a, b):
-    """Returns the inner product as *I* learned it.
-
-    a_i...k * b_k...m = c_i...m     in summation notation with the ...'s
-                                    representing arbitrary, omitted indices
-
-    The sum is over the last axis of the first argument and the first axis
-    of the last axis.
-
-    _myDot(a, b) --> NumPy array
-    """
-
-    a = np.asarray(a)
-    b = np.asarray(b)
-
-    tempAxes = tuple(list(range(1, len(b.shape))) + [0])
-    newB = np.transpose(b, tempAxes)
-
-    # innerproduct sums over the *last* axes of *both* arguments
-    return np.inner(a, newB)
 
 
 def generate_blade_tup_map(bladeTupList):

--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -305,6 +305,10 @@ def grade_obj(objin, threshold=0.0000001):
 
 
 def generate_blade_tup_map(bladeTupList):
+    """
+    Generates a mapping from blade tuple to linear index into
+    multivector
+    """
     blade_map = {}
     for ind,blade in enumerate(bladeTupList):
         blade_map[blade] = ind
@@ -313,6 +317,9 @@ def generate_blade_tup_map(bladeTupList):
 
 @numba.njit
 def count_set_bits(bitmap):
+    """
+    Counts the number of bits set to 1 in bitmap
+    """
     bmp = bitmap
     count = 0
     n = 1
@@ -326,6 +333,10 @@ def count_set_bits(bitmap):
 
 @numba.njit
 def canonical_reordering_sign_euclidean(bitmap_a, bitmap_b):
+    """
+    Computes the sign for the product of bitmap_a and bitmap_b
+    assuming a euclidean metric
+    """
     a = bitmap_a >> 1
     sum_value = 0
     while a != 0:
@@ -339,6 +350,10 @@ def canonical_reordering_sign_euclidean(bitmap_a, bitmap_b):
 
 @numba.njit
 def canonical_reordering_sign(bitmap_a, bitmap_b, metric):
+    """
+    Computes the sign for the product of bitmap_a and bitmap_b
+    given the supplied metric
+    """
     bitmap = bitmap_a & bitmap_b
     output_sign = canonical_reordering_sign_euclidean(bitmap_a, bitmap_b)
     i = 0
@@ -351,6 +366,10 @@ def canonical_reordering_sign(bitmap_a, bitmap_b, metric):
 
 
 def compute_reordering_sign_and_canonical_form(blade, metric):
+    """
+    Takes a tuple blade representation and converts it to a canonical
+    tuple blade representation
+    """
     blade_out = blade[0]
     s = 1
     for b in blade[1:]:
@@ -359,6 +378,10 @@ def compute_reordering_sign_and_canonical_form(blade, metric):
 
 
 def compute_bitmap_representation(blade):
+    """
+    Takes a tuple blade representation and converts it to the
+    bitmap representation
+    """
     if len(blade) > 0:
         bitmap = 1 << (blade[0]-1)
         if len(blade) > 1:
@@ -369,6 +392,10 @@ def compute_bitmap_representation(blade):
         return 0
 
 def compute_blade_representation(bitmap):
+    """
+    Takes a bitmap representation and converts it to the tuple
+    blade representation
+    """
     bmp = bitmap
     blade = []
     n = 1
@@ -498,10 +525,11 @@ class Layout(object):
         self.adjoint_func = get_adjoint_function(self.gradeList)
 
     def dict_to_multivector(self, dict_in):
-      constructed_values = np.zeros(self.gaDims)
-      for k in list(dict_in.keys()):
+        """ Takes a dictionary of coefficient values and converts it into a MultiVector object """
+        constructed_values = np.zeros(self.gaDims)
+        for k in list(dict_in.keys()):
           constructed_values[int(k)] = dict_in[k]
-      return MultiVector(self, constructed_values)
+        return MultiVector(self, constructed_values)
 
 
     def __repr__(self):
@@ -523,6 +551,7 @@ class Layout(object):
             return not np.array_equal(self.sig,other.sig)
 
     def parse_multivector(self,mv_string):
+        """ Parses a multivector string into a MultiVector object """
         # Get the names of the canonical blades
         blade_name_index_map = {name:index for index,name in enumerate(self.names)}
 
@@ -631,10 +660,13 @@ class Layout(object):
                     # A_r _| B_s = <A_r B_s>_(s-r) if s-r >= 0
                     lcmt_nzs[tuple([i,v,j])] = mul
 
+        # This generates the functions that will perform the various products
         self.gmt_func = get_mult_function(gmt_nzs,self.gaDims,self.gradeList)
         self.imt_func = get_mult_function(imt_nzs,self.gaDims,self.gradeList)
         self.omt_func = get_mult_function(omt_nzs,self.gaDims,self.gradeList)
         self.lcmt_func = get_mult_function(lcmt_nzs,self.gaDims,self.gradeList)
+
+        # We store the sparse objects in the layout object
         self.gmt = gmt_nzs
         self.imt = imt_nzs
         self.omt = omt_nzs

--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -607,7 +607,11 @@ class Layout(object):
 
 
     def _gmtElement(self, a, b):
-        "Element of the geometric multiplication table given blades a, b."
+        """
+        Element of the geometric multiplication table given blades a, b.
+        The implementation used here is described in chapter 19 of
+        Leo Dorst's book, Geometric Algebra For Computer Science
+        """
         bitmap_a = compute_bitmap_representation(a)
         bitmap_b = compute_bitmap_representation(b)
         output_sign = canonical_reordering_sign(bitmap_a, bitmap_b, np.array(self.sig))

--- a/clifford/tools/g3c/__init__.py
+++ b/clifford/tools/g3c/__init__.py
@@ -157,8 +157,6 @@ adjoint_func = layout.adjoint_func
 gmt_func = layout.gmt_func
 omt_func = layout.omt_func
 imt_func = layout.imt_func
-rightLaInv = layout.rightLaInv_func
-
 
 
 def get_circle_in_euc(circle):
@@ -349,7 +347,7 @@ def get_radius_from_sphere(sphere):
     Returns the radius of a sphere
     """
     dual_sphere = sphere * I5
-    dual_sphere = dual_sphere / (-dual_sphere | ninf)
+    dual_sphere = dual_sphere / (-dual_sphere | ninf)[0]
     return math.sqrt(abs(dual_sphere * dual_sphere))
 
 

--- a/test_clifford.py
+++ b/test_clifford.py
@@ -177,10 +177,6 @@ class BasicConformalTests(unittest.TestCase):
         t[0] = -1
         np.testing.assert_almost_equal(t, (e12*e12).value)
 
-    def test_up(self):
-        layout = Cl(4, 1)[0]
-        e1 = layout.blades['e1']
-
 
 class BasicAlgebraTests(unittest.TestCase):
 

--- a/test_clifford.py
+++ b/test_clifford.py
@@ -116,6 +116,17 @@ class CliffordTests(unittest.TestCase):
         e1 = blades['e1']
         R*e1*~R
 
+    def test_indexing(self):
+        layout, blades = self.algebras[0]
+        e12 = blades['e12']
+        e1 = blades['e1']
+        e2 = blades['e2']
+        e3 = blades['e3']
+        self.assertAlmostEqual(e12[e12],1)
+        self.assertAlmostEqual(e12[e3], 0)
+        self.assertAlmostEqual(e12[(2,1)], -1)
+
+
     def test_add_float64(self):
         '''
         test array_wrap method to take control addition from numpy array
@@ -127,7 +138,64 @@ class CliffordTests(unittest.TestCase):
         self.assertEqual(1 + e1, float64(1) + e1)
 
 
+class BasicConformalTests(unittest.TestCase):
+    def test_metric(self):
+        layout = Cl(4, 1)[0]
+        e1 = layout.blades['e1']
+        e2 = layout.blades['e2']
+        e3 = layout.blades['e3']
+        e4 = layout.blades['e4']
+        e5 = layout.blades['e5']
+
+        self.assertAlmostEqual((e1 * e1)[0], 1)
+        self.assertAlmostEqual((e2 * e2)[0], 1)
+        self.assertAlmostEqual((e3 * e3)[0], 1)
+        self.assertAlmostEqual((e4 * e4)[0], 1)
+        self.assertAlmostEqual((e5 * e5)[0], -1)
+
+
+    def test_gp_op_ip(self):
+        layout = Cl(4, 1)[0]
+        e1 = layout.blades['e1']
+        e2 = layout.blades['e2']
+        e3 = layout.blades['e3']
+        e4 = layout.blades['e4']
+        e5 = layout.blades['e5']
+
+        e123 = layout.blades['e123']
+        np.testing.assert_almost_equal(e123.value, (e1 ^ e2 ^ e3).value)
+        np.testing.assert_almost_equal(e123.value, (e1 * e2 * e3).value)
+
+        e12345 = layout.blades['e12345']
+        np.testing.assert_almost_equal(e12345.value, (e1 ^ e2 ^ e3 ^ e4 ^ e5).value)
+        np.testing.assert_almost_equal(e12345.value, (e1 * e2 * e3 * e4 * e5).value)
+
+        e12 = layout.blades['e12']
+        np.testing.assert_almost_equal(-e12.value, (e2 ^ e1).value)
+
+        t = np.zeros(32)
+        t[0] = -1
+        np.testing.assert_almost_equal(t, (e12*e12).value)
+
+    def test_up(self):
+        layout = Cl(4, 1)[0]
+        e1 = layout.blades['e1']
+
+
 class BasicAlgebraTests(unittest.TestCase):
+
+    def test_gp_op_ip(self):
+        layout = Cl(3)[0]
+        e1 = layout.blades['e1']
+        e2 = layout.blades['e2']
+        e3 = layout.blades['e3']
+
+        e123 = layout.blades['e123']
+        np.testing.assert_almost_equal(e123.value, (e1 ^ e2 ^ e3).value)
+        np.testing.assert_almost_equal(e123.value, (e1 * e2 * e3).value)
+
+        e12 = layout.blades['e12']
+        np.testing.assert_almost_equal(-e12.value, (e2 ^ e1).value)
 
     def test_grade_obj(self):
         algebras = [Cl(i) for i in [3, 4]] + [conformalize(Cl(3)[0])]


### PR DESCRIPTION
This commit removes the very large and very sparse matrices from the Layout object and instead directly generates a dictionary of values that would index into the sparse matrix.
This results in much lower memory  usage and is a step towards fast and efficient caching of algebras, we should just need to store these sparse objects.
In order to get this to work I had to nuke the right inverse function. I am not entirely sure why this was in there to begin with and its removal does not seem to break any of my code...