### PR TITLE
added array() method to make MVarray use easier, removed numpy array …

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -50,7 +50,7 @@ from warnings import warn
 
 # Major library imports.
 import numpy as np
-from numpy import linalg, array,zeros
+from numpy import linalg,zeros
 import numba
 
 
@@ -1796,7 +1796,7 @@ class MultiVector(object):
         else:
             raise ValueError("no inverse exists for this multivector")
             
-
+    
     
 
     def inv(self):
@@ -2128,6 +2128,28 @@ class MVArray(np.ndarray):
             out= out^k
         return out
 
+def array(obj):
+    '''
+    an array method like numpy.array(), but returns a MVArray
+    
+    Parameters
+    -------------
+    obj : MultiVector, list 
+        a MV or a list of MV's 
+        
+    Examples
+    ----------
+    >>>import clifford as cf
+    >>>from clifford import g3
+    >>>import numpy as np
+    >>>np.random.rand(10)*cf.array(g3.e12)
+    '''
+    if isinstance(obj, MultiVector):
+        # they passed a single MV so make a list of it. 
+        return MVArray([obj])
+    else:
+        return MVArray(obj)
+
 class Frame(MVArray):
     '''
     A frame of vectors
@@ -2195,7 +2217,7 @@ class Frame(MVArray):
             eps=_eps
             
             
-        return array([float((b[m]|b[n]) - (a[m]|a[n]))<eps for m, n in pairs]).all()
+        return np.array([float((b[m]|b[n]) - (a[m]|a[n]))<eps for m, n in pairs]).all()
 
 
 class BladeMap(object):
@@ -2631,6 +2653,7 @@ def conformalize(layout, added_sig=[1,-1]):
         'up': up, 'down': down, 'homo': homo,'I_base':I_base})
 
     return layout_c, blades_c, stuff
+
 
 
 ## TODO: fix caching to work


### PR DESCRIPTION
…import from init.py. @hugohadfield  do you think re-using `array()` like this is bad?  i figured it would only cause problems if you do `from clifford import * ` and it overwrites `numpy.array`

this now works, which is a little easier 

    from clifford import g3,array
    import numpy as np
    theta = np.linspace(0,2*np.pi,10)
    np.e**(theta*array(g3.e12))