### PR TITLE
Fix DeprecationWarning: invalid escape sequence

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -60,7 +60,7 @@ from clifford.io import write_ga_file, read_ga_file
 __version__ = '1.0.5'
 
 # The blade finding regex for parsing strings of mvs
-_blade_pattern =  "((^|\s)-?\s?\d+(\.\d+)?)\s|(-\s?(\d+((e(\+|-))|\.)?(\d+)?)\^e\d+(\s|$))|((^|\+)\s?(\d+((e(\+|-))|\.)?(\d+)?)\^e\d+(\s|$))"
+_blade_pattern =  r"((^|\s)-?\s?\d+(\.\d+)?)\s|(-\s?(\d+((e(\+|-))|\.)?(\d+)?)\^e\d+(\s|$))|((^|\+)\s?(\d+((e(\+|-))|\.)?(\d+)?)\^e\d+(\s|$))"
 _eps = 1e-12            # float epsilon for float comparisons
 _pretty = True          # pretty-print global
 _print_precision = 5    # pretty printing precision on floats
@@ -2129,7 +2129,7 @@ class MultiVector(object):
             raise ValueError("not blades")
 
     def meet(self, other, subspace=None):
-        """Returns the meet of two blades.
+        r"""Returns the meet of two blades.
 
         Computation is done with respect to a subspace that defaults to
         the join if none is given.


### PR DESCRIPTION
If `\` is not used as part of an escape sequence, it needs to be either a raw string or escaped as `\\`.

This is needed to work at all in python 3.8