### PR TITLE
Vindicate victor of versor versus verser

### DIFF
--- a/clifford/test/test_tools.py
+++ b/clifford/test/test_tools.py
@@ -2,7 +2,7 @@ from clifford import Cl
 
 import unittest
 
-from clifford.tools import orthoFrames2Verser as of2v
+from clifford.tools import orthoFrames2Versor as of2v
 import numpy as np
 
 from numpy import exp, float64, testing
@@ -24,26 +24,26 @@ class ToolsTests(unittest.TestCase):
         # create rotated frame
         B = [R*a*~R for a in A]
 
-        # find verser from both frames
+        # find versor from both frames
         R_found, rs = of2v(A, B)
 
         # Rotor is determiend correctly, within a sign
         self.assertTrue(R == R_found or R == -R_found)
 
-        # Determined Verser implements desired transformation
+        # Determined Versor implements desired transformation
         self.assertTrue([R_found*a*~R_found for a in A] == B)
 
-    def testOrthoFrames2VerserEuclidean(self):
+    def testOrthoFrames2VersorEuclidean(self):
         for p, q in [(2, 0), (3, 0), (4, 0)]:
             self.checkit(p=p, q=q)
 
     @unittest.skip("reason unknown")  # fails
-    def testOrthoFrames2VerserMinkowski(self):
+    def testOrthoFrames2VersorMinkowski(self):
         for p, q in [(1, 1), (2, 1), (3, 1)]:
             self.checkit(p=p, q=q)
 
     @unittest.skip("reason unknown")  # fails
-    def testOrthoFrames2VerserBalanced(self):
+    def testOrthoFrames2VersorBalanced(self):
         for p, q in [(2, 2)]:
             self.checkit(p=p, q=q)
 

--- a/clifford/tools/__init__.py
+++ b/clifford/tools/__init__.py
@@ -29,13 +29,13 @@ create the algorithms below can be found at Allan Cortzen's website.
 
 There are also some helper functions which can be used to translate matrices
 into GA frames, so an orthogonal (or complex unitary ) matrix can be directly
-translated into a Verser.
+translated into a Versor.
 
 .. autosummary::
     :toctree: generated/
 
-    orthoFrames2Verser
-    orthoMat2Verser
+    orthoFrames2Versor
+    orthoMat2Versor
     mat2Frame
 
 """
@@ -176,9 +176,9 @@ def frame2Mat(B, A=None, is_complex=None):
     M = array(M).reshape(len(B), len(B))
 
 
-def orthoFrames2Verser_dist(A, B, eps=None):
+def orthoFrames2Versor_dist(A, B, eps=None):
     '''
-    Determines verser for two frames related by an orthogonal transform
+    Determines versor for two frames related by an orthogonal transform
 
     The frames themselves do not have to be othorgonal.
 
@@ -233,10 +233,10 @@ def orthoFrames2Verser_dist(A, B, eps=None):
     return R, r_list
 
 
-def orthoFrames2Verser(B, A=None, delta=1e-3, eps=None, det=None,
+def orthoFrames2Versor(B, A=None, delta=1e-3, eps=None, det=None,
                        remove_scaling=False):
     '''
-    Determines verser for two frames related by an orthogonal transform
+    Determines versor for two frames related by an orthogonal transform
 
     Based on [1,2]. This works  in Euclidean spaces and, under special
     circumstances in other signatures. see [1] for limitaions/details
@@ -334,9 +334,9 @@ def orthoFrames2Verser(B, A=None, delta=1e-3, eps=None, det=None,
         # whatever,  it might still work
         pass
    
-    # Find the Verser
+    # Find the Versor
 
-    # store each reflector/rotor  in a list,  make full verser at the
+    # store each reflector/rotor  in a list,  make full versor at the
     # end of the loop
     r_list = []
 
@@ -390,13 +390,13 @@ def orthoFrames2Verser(B, A=None, delta=1e-3, eps=None, det=None,
     return R, r_list
 
 
-def orthoMat2Verser(A, eps=None, layout=None, is_complex=None):
+def orthoMat2Versor(A, eps=None, layout=None, is_complex=None):
     '''
-    Translates an orthogonal (or unitary) matrix to a Verser
+    Translates an orthogonal (or unitary) matrix to a Versor
 
     `A` is interpreted as the frame produced by transforming a
     orthonormal frame by an orthogonal transform. Given this relation,
-    this function will find the verser which enacts this transform.
+    this function will find the versor which enacts this transform.
 
 
     Parameters
@@ -409,7 +409,7 @@ def orthoMat2Verser(A, eps=None, layout=None, is_complex=None):
     # if (A.dot(A.conj().T) -eye(N/2)).max()>eps:
     #     warn('A doesnt appear to be a rotation. ')
     A, layout = mat2Frame(eye(N), layout=layout, is_complex=False)
-    return orthoFrames2Verser(A=A, B=B, eps=eps)
+    return orthoFrames2Versor(A=A, B=B, eps=eps)
 
 
 def rotor_decomp(V, x):

--- a/clifford/tools/g3c/rotor_estimation.py
+++ b/clifford/tools/g3c/rotor_estimation.py
@@ -8,7 +8,7 @@ from scipy.optimize import minimize
 from .rotor_parameterisation import rotorconversion
 from . import rotor_between_objects, apply_rotor, square_roots_of_rotor, rotor_between_lines, normalised
 from clifford.g3c import *
-from clifford.tools import orthoFrames2Verser as cartan
+from clifford.tools import orthoFrames2Versor as cartan
 from clifford.tools.g3c import *
 from .cost_functions import object_set_cost_sum, rotor_cost, val_rotor_cost_sparse
 from clifford import grade_obj, MVArray

--- a/docs/ConformalGeometricAlgebra.ipynb
+++ b/docs/ConformalGeometricAlgebra.ipynb
@@ -179,11 +179,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Conformal transformations in $G_n$ are achieved through versers in the conformal space $G_{n+1,1}$. These versers can be categorized by their relation to the added minkowski plane, $E_0$. There are three categories,\n",
+    "Conformal transformations in $G_n$ are achieved through versors in the conformal space $G_{n+1,1}$. These versors can be categorized by their relation to the added minkowski plane, $E_0$. There are three categories,\n",
     "\n",
-    "* verser purely in $E_0$\n",
-    "* verser partly in $E_0$\n",
-    "* verser out of $E_0$\n",
+    "* versor purely in $E_0$\n",
+    "* versor partly in $E_0$\n",
+    "* versor out of $E_0$\n",
     "\n",
     "\n",
     "A three dimensional projection for conformal space with the relevant subspaces labeled is shown below. "
@@ -205,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Versers purely in $E_0$"
+    "## Versors purely in $E_0$"
    ]
   },
   {
@@ -314,7 +314,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Versers partly in $E_0$"
+    "## Versors partly in $E_0$"
    ]
   },
   {
@@ -354,7 +354,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A transversion is an inversion,  followed by a translation, followed by a inversion. The verser is \n",
+    "A transversion is an inversion,  followed by a translation, followed by a inversion. The versor is \n",
     "\n",
     "$$V= e_+ T_a e_+$$\n",
     "\n",
@@ -389,14 +389,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Versers Out of  $E_0$"
+    "## Versors Out of  $E_0$"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Versers that are out of $E_0$ are made up of the versers within the original space. These include reflections and rotations, and their conformal representation is identical to their form in $G^n$, except the minus sign is dropped for reflections, "
+    "Versors that are out of $E_0$ are made up of the versors within the original space. These include reflections and rotations, and their conformal representation is identical to their form in $G^n$, except the minus sign is dropped for reflections, "
    ]
   },
   {

--- a/docs/EulerAngles.ipynb
+++ b/docs/EulerAngles.ipynb
@@ -252,7 +252,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In 3 Dimenions, there is a simple formula which can be used to directly transform a rotations matrix into a rotor. For arbitrary dimensions you have to use a different algorithm (see `orthoMat2Verser()` in `clifford.tools`).  Anyway, in 3 dimensions there is a closed form solution, as described in  Sec. 4.3.3 of \"Geometric Algebra for Physicists\".   Given a rotor $R$ which transforms an  orthonormal frame $A={a_k}$  into $B={b_k}$ as such,\n",
+    "In 3 Dimenions, there is a simple formula which can be used to directly transform a rotations matrix into a rotor. For arbitrary dimensions you have to use a different algorithm (see `orthoMat2Versor()` in `clifford.tools`).  Anyway, in 3 dimensions there is a closed form solution, as described in  Sec. 4.3.3 of \"Geometric Algebra for Physicists\".   Given a rotor $R$ which transforms an  orthonormal frame $A={a_k}$  into $B={b_k}$ as such,\n",
     "\n",
     "$$b_k = Ra_k\\tilde{R}$$\n",
     "\n",


### PR DESCRIPTION
The correct spelling is `versor`, as in `motor`, `rotor`, `vector`, ...