### PR TITLE
Preserve integers in multiplications

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -286,9 +286,9 @@ class Layout(object):
             self.bitmap_to_linear_map,
             self.sig
         )
-        self.omt = sparse.where(omt_prod_mask, self.gmt, 0)
-        self.imt = sparse.where(imt_prod_mask, self.gmt, 0)
-        self.lcmt = sparse.where(lcmt_prod_mask, self.gmt, 0)
+        self.omt = sparse.where(omt_prod_mask, self.gmt, self.gmt.dtype.type(0))
+        self.imt = sparse.where(imt_prod_mask, self.gmt, self.gmt.dtype.type(0))
+        self.lcmt = sparse.where(lcmt_prod_mask, self.gmt, self.gmt.dtype.type(0))
 
         # This generates the functions that will perform the various products
         self.gmt_func = get_mult_function(self.gmt, self.gradeList)

--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -990,3 +990,13 @@ class MultiVector(object):
             subspace = self.join(other)
 
         return (self * subspace.inv()) | other
+
+    def astype(self, *args, **kwargs):
+        """
+        Change the underlying scalar type of this vector.
+
+        Can be used to force lower-precision floats or integers
+
+        See `np.ndarray.astype` for argument descriptions.
+        """
+        return self._newMV(self.value.astype(*args, **kwargs))

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -233,17 +233,21 @@ class TestClifford:
         assert str(-e1) == "-(1^e1)"
         assert str(1 - e1) == "1 - (1^e1)"
 
+    @pytest.mark.parametrize('dtype', [np.int64, np.float32, np.float64])
     @pytest.mark.parametrize('func', [
         operator.add,
         operator.sub,
+        operator.mul,
+        operator.xor,  # outer product
+        operator.or_,  # inner product
     ])
-    def test_binary_op_preserves_dtype(self, func):
+    def test_binary_op_preserves_dtype(self, dtype, func):
         """ test that simple binary ops on blades do not promote types """
         layout, blades = Cl(3)
-        e1 = blades['e1']
-        e2 = blades['e2']
-        assert func(e1, 1).value.dtype == e1.value.dtype
-        assert func(e1, e2).value.dtype == e1.value.dtype
+        e1 = blades['e1'].astype(dtype)
+        e2 = blades['e2'].astype(dtype)
+        assert func(e1, np.int8(1)).value.dtype == dtype
+        assert func(e1, e2).value.dtype == dtype
 
     @pytest.mark.parametrize('func', [
         operator.inv,


### PR DESCRIPTION
Previously these were cast to floats which could lose precision.

This makes the output a little cleaner for pedagogical cases.

This also allows the use of other floating types