### PR TITLE
Remove get_longest_string

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -58,8 +58,7 @@ __version__ = '1.0.5'
 # The blade finding regex for parsing strings of mvs
 _blade_pattern = re.compile(r"""
     ((^|\s)-?\s?\d+(\.\d+)?)\s|
-    (     -\s?(\d+((e(\+|-))|\.)?(\d+)?)\^e\d+(\s|$))|
-    ((^|\+)\s?(\d+((e(\+|-))|\.)?(\d+)?)\^e\d+(\s|$))
+    ((^|\+|-)\s?(\d+((e(\+|-))|\.)?(\d+)?)\^e\d+(\s|$))
 """, re.VERBOSE)
 _eps = 1e-12            # float epsilon for float comparisons
 _pretty = True          # pretty-print global

--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -709,7 +709,7 @@ class Layout(object):
         else:
             return NotImplemented
 
-    def parse_multivector(self, mv_string):
+    def parse_multivector(self, mv_string: str) -> 'MultiVector':
         """ Parses a multivector string into a MultiVector object """
         # Get the names of the canonical blades
         blade_name_index_map = {name: index for index, name in enumerate(self.names)}


### PR DESCRIPTION
Using finditer instead of findall allows us to directly extract the match, rather than search for it in the groups.

Also switch the regex to verbose mode, for readability.

