### PR TITLE
Combine the k_list, l_list, m_list, and mult_table_vals into a class

### DIFF
--- a/clifford/code_gen.py
+++ b/clifford/code_gen.py
@@ -1,16 +1,19 @@
 from __future__ import print_function
 import numpy as np
 
-def generate_mult_function_batch_compile(k_list, l_list, m_list, mult_table_vals, n_dims,
+def generate_mult_function_batch_compile(gmt,
                                          product_name, product_mask=None, cuda=False):
     """
     Takes a given product and generates the code for a function that evaluates it
     """
     if product_mask is not None:
-        k_list = k_list[product_mask]
-        l_list = l_list[product_mask]
-        m_list = m_list[product_mask]
-        mult_table_vals = mult_table_vals[product_mask]
+        gmt = gmt.masked(product_mask)
+
+    k_list = gmt._k_list
+    l_list = gmt._l_list
+    m_list = gmt._m_list
+    mult_table_vals = gmt._val_list
+    n_dims = gmt._dims
 
     # Sort them by l list
     arg_list = np.argsort(l_list)
@@ -47,12 +50,12 @@ def generate_mult_function_batch_compile(k_list, l_list, m_list, mult_table_vals
     return total_string
 
 
-def write_mult_function_batch_compile(k_list, l_list, m_list, mult_table_vals, n_dims, product_name, file_obj,
+def write_mult_function_batch_compile(gmt, product_name, file_obj,
                                              product_mask=None, cuda=False):
     """
     Takes a given product and generates the code for a function that evaluates it, saves this to file
     """
-    total_string = generate_mult_function_batch_compile(k_list, l_list, m_list, mult_table_vals, n_dims,
+    total_string = generate_mult_function_batch_compile(gmt,
                                                         product_name, product_mask=product_mask, cuda=cuda)
     print(total_string, file=file_obj)
 
@@ -65,15 +68,12 @@ def write_algebra(file_name, layout, cuda=False):
         # Write the preamble
         print('import numpy as np\nfrom numba import njit, cuda\n\n', file=file_obj)
         # Write the gmt
-        write_mult_function_batch_compile(layout.k_list, layout.l_list, layout.m_list, layout.mult_table_vals,
-                                          layout.gaDims, 'gmt_func', file_obj, cuda=cuda)
+        write_mult_function_batch_compile(layout.gmt, 'gmt_func', file_obj, cuda=cuda)
         # Write the omt
-        write_mult_function_batch_compile(layout.k_list, layout.l_list, layout.m_list, layout.mult_table_vals,
-                                          layout.gaDims, 'omt_func', file_obj,
+        write_mult_function_batch_compile(layout.gmt, 'omt_func', file_obj,
                                           product_mask=layout.omt_prod_mask, cuda=cuda)
         # Write the imt
-        write_mult_function_batch_compile(layout.k_list, layout.l_list, layout.m_list, layout.mult_table_vals,
-                                          layout.gaDims, 'imt_func', file_obj,
+        write_mult_function_batch_compile(layout.gmt, 'imt_func', file_obj,
                                           product_mask=layout.imt_prod_mask, cuda=cuda)
 
 if __name__ == '__main__':

--- a/clifford/tools/g3c/__init__.py
+++ b/clifford/tools/g3c/__init__.py
@@ -159,8 +159,7 @@ from clifford.tools.g3 import quaternion_to_rotor, random_euc_mv, \
     random_rotation_rotor, generate_rotation_rotor, val_random_euc_mv
 from clifford.g3c import *
 import clifford as cf
-from clifford import val_get_left_gmt_matrix, val_get_right_gmt_matrix, \
-    grades_present, NUMBA_PARALLEL, MVArray
+from clifford import grades_present, NUMBA_PARALLEL, MVArray
 import warnings
 from scipy.interpolate import interp1d
 
@@ -495,29 +494,24 @@ def scale_TR_translation(TR, scale):
     new_TR = (generate_translation_rotor(t)*R_only).normal()
     return new_TR
 
-def left_gmt_generator():
-    k_list = layout.k_list
-    l_list = layout.l_list
-    m_list = layout.m_list
-    mult_table_vals = layout.mult_table_vals
-    gaDims = layout.gaDims
+
+def left_gmt_generator(mt=layout.gmt):
+    # unpack for numba
+    k_list = mt._k_list
+    l_list = mt._l_list
+    m_list = mt._m_list
+    mult_table_vals = mt._val_list
+    gaDims = mt._dims
+    val_get_left_gmt_matrix = cf._MultiplicationTable._numba_val_get_left_matrix
+
     @numba.njit
     def get_left_gmt(x_val):
         return val_get_left_gmt_matrix(x_val, k_list, l_list,
                                 m_list, mult_table_vals, gaDims)
     return get_left_gmt
 
-def right_gmt_generator():
-    k_list = layout.k_list
-    l_list = layout.l_list
-    m_list = layout.m_list
-    mult_table_vals = layout.mult_table_vals
-    gaDims = layout.gaDims
-    @numba.njit
-    def get_right_gmt(x_val):
-        return val_get_right_gmt_matrix(x_val, k_list, l_list,
-                                m_list, mult_table_vals, gaDims)
-    return get_right_gmt
+def right_gmt_generator(mt=layout.gmt):
+    return left_gmt_generator(mt.T)
 
 get_left_gmt_matrix = left_gmt_generator()
 get_right_gmt_matrix = right_gmt_generator()


### PR DESCRIPTION
Combine the k_list, l_list, m_list, and mult_table_vals into a class …

This gives a convenient place to attach methods, and reduced the number of arguments for a lot of functions

Since this moves functions to methods, review with this setting turned on:
![image](https://user-images.githubusercontent.com/425260/66925959-19ded180-f025-11e9-8fb4-0bccb8f986c9.png)



---

Add nonzero and getitem to fix gh-93

These methods are super inefficient, but they are enough to fix the old code.

---

This change is pretty wide-reaching, and I probably haven't got it right first time. This should make the API compatible with how it was before gh-93 (!).

It's likely I will try to split this into smaller PRs (done)