### PR TITLE
Fix `Layout.blades_of_grade(0)` to return the right type

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -39,7 +39,7 @@ Functions
 from functools import reduce
 import os
 import itertools
-from typing import List, Tuple, Set
+from typing import List, Tuple, Set, Container, Dict, Optional
 
 # Major library imports.
 import numpy as np
@@ -724,7 +724,7 @@ def Cl(p=0, q=0, r=0, sig=None, names=None, firstIdx=1, mvClass=MultiVector):
     return layout, blades
 
 
-def bases(layout, mvClass=MultiVector, grades=None):
+def bases(layout, mvClass=MultiVector, grades: Optional[Container[int]] = None) -> Dict[str, MultiVector]:
     """Returns a dictionary mapping basis element names to their MultiVector
     instances, optionally for specific grades
 
@@ -733,18 +733,18 @@ def bases(layout, mvClass=MultiVector, grades=None):
 
     >>> locals().update(layout.blades())
 
-    bases(layout) --> {'name': baseElement, ...}
+    .. versionchanged:: 1.1.0
+        This dictionary includes the scalar
     """
 
     dict = {}
     for i in range(layout.gaDims):
         grade = layout.gradeList[i]
-        if grade != 0:
-            if grades is not None and grade not in grades:
-                continue
-            v = np.zeros((layout.gaDims,), dtype=int)
-            v[i] = 1
-            dict[layout.names[i]] = mvClass(layout, v)
+        if grades is not None and grade not in grades:
+            continue
+        v = np.zeros((layout.gaDims,), dtype=int)
+        v[i] = 1
+        dict[layout.names[i]] = mvClass(layout, v)
     return dict
 
 

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -1,5 +1,6 @@
 import re
 from functools import reduce
+from typing import List
 
 import numpy as np
 import numba
@@ -465,7 +466,7 @@ class Layout(object):
         d = self.basis_vectors
         return [d[k] for k in sorted(d.keys())]
 
-    def blades_of_grade(self, grade):
+    def blades_of_grade(self, grade: int) -> List['MultiVector']:
         '''
         return all blades of a given grade,
 
@@ -478,19 +479,15 @@ class Layout(object):
         --------
         blades : list of MultiVectors
         '''
-        if grade == 0:
-            return self.scalar
-        return [k for k in self.blades_list[1:] if k.grades() == {grade}]
+        return [k for k in self.blades_list if k.grades() == {grade}]
 
     @property
-    def blades_list(self):
+    def blades_list(self) -> List['MultiVector']:
         '''
-        Ordered list of blades in this layout (with scalar as [0])
+        List of blades in this layout matching the order of `self.bladeTupList`
         '''
         blades = self.blades
-        names = self.names
-        N = self.gaDims
-        return [1.0] + [blades[names[k]] for k in range(1, N)]
+        return [blades[n] for n in self.names]
 
     @property
     def blades(self):

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -351,6 +351,7 @@ class TestBasicConformal41:
         e1 = layout.blades['e1']
         e2 = layout.blades['e2']
         e3 = layout.blades['e3']
+        assert layout.blades_of_grade(0) == [layout.scalar]
         assert layout.blades_of_grade(1) == [e1, e2, e3]
         assert layout.blades_of_grade(2) == [e1^e2, e1^e3, e2^e3]
         assert layout.blades_of_grade(3) == [e1^e2^e3]


### PR DESCRIPTION
Previously this returned a single float, but it should have returned a list of multivectors

This also changes `clifford.bases` to include the scalar in its returned dictionary.
This seems eminently reasonable, since the scalar is itself a base.
The only weirdness is that `locals().update(layout.blades())` will now set the variable `''` to something, but nothing can read that anyway.

Adds some type annotations while we're here.