### PR TITLE
Fix `clifford.test.run_all_tests` to use pytest

### DIFF
--- a/clifford/test/__init__.py
+++ b/clifford/test/__init__.py
@@ -1,12 +1,6 @@
-from .test_algebra_initialisation import *
-from .test_clifford import *
-from .test_io import *
-from .test_g3c_tools import *
-from .test_tools import *
-from .test_g3c_CUDA import *
+import os
+import pytest
 
-import unittest
-
-
-def run_all_tests():
-    unittest.main()
+def run_all_tests(*args):
+    """ Invoke pytest, forwarding options to pytest.main """
+    pytest.main([os.path.dirname(__file__)] + list(args))


### PR DESCRIPTION
Closes gh-91. Tests can be run with
```python
import clifford.test
clifford.test.run_all_tests()
```