### PR TITLE
Avoid type promotion in `MultiVector.__invert__`

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -84,7 +84,7 @@ def get_adjoint_function(gradeList):
     This function returns a fast jitted adjoint function
     '''
     grades = np.array(gradeList)
-    signs = np.power(-1, grades*(grades-1)/2)
+    signs = np.power(-1, grades*(grades-1)//2)
     @numba.njit
     def adjoint_func(value):
         return signs * value  # elementwise multiplication

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -224,13 +224,29 @@ class TestClifford:
         assert str(-e1) == "-(1^e1)"
         assert str(1 - e1) == "1 - (1^e1)"
 
-    def test_add_preserves_dtype(self):
-        """ test that adding blades does not promote types """
+    @pytest.mark.parametrize('func', [
+        operator.add,
+        operator.sub,
+    ])
+    def test_binary_op_preserves_dtype(self, func):
+        """ test that simple binary ops on blades do not promote types """
         layout, blades = Cl(3)
         e1 = blades['e1']
         e2 = blades['e2']
-        assert (e1 + 1).value.dtype == e1.value.dtype
-        assert (e1 + e2).value.dtype == e1.value.dtype
+        assert func(e1, 1).value.dtype == e1.value.dtype
+        assert func(e1, e2).value.dtype == e1.value.dtype
+
+    @pytest.mark.parametrize('func', [
+        operator.inv,
+        operator.pos,
+        operator.neg,
+        MultiVector.gradeInvol,
+    ])
+    def test_unary_op_preserves_dtype(self, func):
+        """ test that simple unary ops on blades do not promote types """
+        layout, blades = Cl(3)
+        e1 = blades['e1']
+        assert func(e1).value.dtype == e1.value.dtype
 
     def test_indexing_blade_tuple(self):
         # gh-151


### PR DESCRIPTION
Also adds better tests for checking for type promotion.