### PR TITLE
Add pyganja dependency to ReadTheDocs yml config

### DIFF
--- a/readthedocs-environment.yml
+++ b/readthedocs-environment.yml
@@ -12,3 +12,5 @@ dependencies:
     - ipykernel
     - nbsphinx
     - nbconvert=5.4.1
+    - pip:
+        - pyganja


### PR DESCRIPTION
This was only added to the pip config, so didn't work when built in conda