### PR TITLE
Unify setup, __init__, and conf version numbers

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -50,8 +50,7 @@ import sparse
 
 from clifford.io import write_ga_file, read_ga_file  # noqa: F401
 
-
-__version__ = '1.0.5'
+from ._version import __version__  # noqa: F401
 
 _eps = 1e-12            # float epsilon for float comparisons
 _pretty = True          # pretty-print global

--- a/clifford/_version.py
+++ b/clifford/_version.py
@@ -1,0 +1,8 @@
+# Package versioning solution originally found here:
+# http://stackoverflow.com/q/458550
+
+# Store the version here so:
+# 1) we don't load dependencies by storing it in __init__.py
+# 2) we can import it in setup.py for the same reason
+# 3) we can import it into your module
+__version__ = '1.0.5'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,10 +16,12 @@ import sys
 import os
 import sphinx_rtd_theme
 
+from clifford import __version__
+
 # The short X.Y version.
-version = '1.0.5'
+version = __version__
 # The full version, including alpha/beta/rc tags.
-release = version
+release = __version__
 
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
This uses the approach taken by https://github.com/sphinx-contrib/napoleon

The version number is still repeated in the git tag, but that's harder to screw up.

Fixes gh-45