### PR TITLE
Add primitive numba support for Layout and MultiVector

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -81,7 +81,7 @@ from typing import List, Tuple, Set
 
 # Major library imports.
 import numpy as np
-import numba
+import numba as _numba  # to avoid clashing with clifford.numba
 import sparse
 try:
     from numba.np import numpy_support as _numpy_support
@@ -146,7 +146,7 @@ def get_mult_function(mt: sparse.COO, gradeList,
         return _get_mult_function_runtime_sparse(mt)
 
 
-def _get_mult_function_result_type(a: numba.types.Type, b: numba.types.Type, mt: np.dtype):
+def _get_mult_function_result_type(a: _numba.types.Type, b: _numba.types.Type, mt: np.dtype):
     a_dt = _numpy_support.as_dtype(getattr(a, 'dtype', a))
     b_dt = _numpy_support.as_dtype(getattr(b, 'dtype', b))
     return np.result_type(a_dt, mt, b_dt)
@@ -324,6 +324,9 @@ from ._conformal_layout import ConformalLayout  # noqa: E402
 from ._layout_helpers import BasisVectorIds, BasisBladeOrder  # noqa: F401
 from ._mvarray import MVArray, array  # noqa: F401
 from ._frame import Frame  # noqa: F401
+
+# this registers the extension type
+from . import numba  # noqa: F401
 from ._blademap import BladeMap  # noqa: F401
 
 

--- a/clifford/numba/__init__.py
+++ b/clifford/numba/__init__.py
@@ -1,0 +1,2 @@
+from ._multivector import MultiVectorType
+from ._layout import LayoutType

--- a/clifford/numba/_layout.py
+++ b/clifford/numba/_layout.py
@@ -1,0 +1,50 @@
+import numba
+import numba.extending
+try:
+    # module locations as of numba 0.49.0
+    from numba.core import cgutils, types
+except ImportError:
+    # module locations prior to numba 0.49.0
+    from numba import cgutils, types
+
+from .._layout import Layout
+
+
+# Taken from numba_passthru
+opaque_pyobject = types.Opaque('Opaque(PyObject)')
+
+
+class LayoutType(types.Type):
+    def __init__(self):
+        super().__init__("LayoutType")
+
+
+@numba.extending.register_model(LayoutType)
+class LayoutModel(numba.extending.models.StructModel):
+    def __init__(self, dmm, fe_typ):
+        members = [
+            ('meminfo', types.MemInfoPointer(opaque_pyobject)),
+        ]
+        super().__init__(dmm, fe_typ, members)
+
+
+@numba.extending.typeof_impl.register(Layout)
+def _typeof_Layout(val: Layout, c) -> LayoutType:
+    return LayoutType()
+
+
+# Derived from numba_passthru
+
+@numba.extending.unbox(LayoutType)
+def unbox_Layout(typ, obj, context):
+    layout = cgutils.create_struct_proxy(typ)(context.context, context.builder)
+    layout.meminfo = context.pyapi.nrt_meminfo_new_from_pyobject(obj, obj)
+    return numba.extending.NativeValue(layout._getvalue())
+
+
+@numba.extending.box(LayoutType)
+def box_Layout(typ, val, context):
+    val = cgutils.create_struct_proxy(typ)(context.context, context.builder, value=val)
+    obj = context.context.nrt.meminfo_data(context.builder, val.meminfo)
+    context.pyapi.incref(obj)
+    return obj

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -1,0 +1,107 @@
+"""
+Numba support for MultiVector objects.
+
+For now, this just supports .value wrapping / unwrapping
+"""
+import numpy as np
+import numba
+from numba.extending import NativeValue
+
+try:
+    # module locations as of numba 0.49.0
+    import numba.np.numpy_support as _numpy_support
+    from numba.core.imputils import impl_ret_borrowed
+    from numba.core import cgutils, types
+except ImportError:
+    # module locations prior to numba 0.49.0
+    import numba.numpy_support as _numpy_support
+    from numba.targets.imputils import impl_ret_borrowed
+    from numba import cgutils, types
+
+from .._multivector import MultiVector
+
+from ._layout import LayoutType
+
+__all__ = ['MultiVectorType']
+
+
+class MultiVectorType(types.Type):
+    def __init__(self, dtype: np.dtype):
+        assert isinstance(dtype, np.dtype)
+        self.dtype = dtype
+        super().__init__(name='MultiVector[{!r}]'.format(numba.from_dtype(dtype)))
+
+    @property
+    def key(self):
+        return self.dtype
+
+    @property
+    def value_type(self):
+        return numba.from_dtype(self.dtype)[:]
+
+    @property
+    def layout_type(self):
+        return LayoutType()
+
+
+@numba.extending.typeof_impl.register(MultiVector)
+def _typeof_MultiVector(val: MultiVector, c) -> MultiVectorType:
+    return MultiVectorType(dtype=val.value.dtype)
+
+
+@numba.extending.register_model(MultiVectorType)
+class MultiVectorModel(numba.extending.models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ('layout', fe_type.layout_type),
+            ('value', fe_type.value_type),
+        ]
+        super().__init__(dmm, fe_type, members)
+
+
+@numba.extending.type_callable(MultiVector)
+def type_MultiVector(context):
+    def typer(layout, value):
+        if isinstance(layout, LayoutType) and isinstance(value, types.Array):
+            return MultiVectorType(_numpy_support.as_dtype(value.dtype))
+    return typer
+
+
+@numba.extending.lower_builtin(MultiVector, LayoutType, types.Any)
+def impl_MultiVector(context, builder, sig, args):
+    typ = sig.return_type
+    layout, value = args
+    mv = cgutils.create_struct_proxy(typ)(context, builder)
+    mv.layout = layout
+    mv.value = value
+    return impl_ret_borrowed(context, builder, sig.return_type, mv._getvalue())
+
+
+@numba.extending.unbox(MultiVectorType)
+def unbox_MultiVector(typ: MultiVectorType, obj: MultiVector, c) -> NativeValue:
+    value = c.pyapi.object_getattr_string(obj, "value")
+    layout = c.pyapi.object_getattr_string(obj, "layout")
+    mv = cgutils.create_struct_proxy(typ)(c.context, c.builder)
+    mv.layout = c.unbox(typ.layout_type, layout).value
+    mv.value = c.unbox(typ.value_type, value).value
+    c.pyapi.decref(value)
+    c.pyapi.decref(layout)
+    is_error = cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
+    return NativeValue(mv._getvalue(), is_error=is_error)
+
+
+@numba.extending.box(MultiVectorType)
+def box_MultiVector(typ: MultiVectorType, val: NativeValue, c) -> MultiVector:
+    mv = cgutils.create_struct_proxy(typ)(c.context, c.builder, value=val)
+    mv_obj = c.box(typ.value_type, mv.value)
+    layout_obj = c.box(typ.layout_type, mv.layout)
+    class_obj = c.pyapi.unserialize(c.pyapi.serialize_object(MultiVector))
+    res = c.pyapi.call_function_objargs(class_obj, (layout_obj, mv_obj))
+    c.pyapi.decref(mv_obj)
+    c.pyapi.decref(class_obj)
+    c.pyapi.decref(layout_obj)
+    return res
+
+
+numba.extending.make_attribute_wrapper(MultiVectorType, 'value', 'value')
+numba.extending.make_attribute_wrapper(MultiVectorType, 'layout', 'layout')

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -1,0 +1,43 @@
+import numba
+
+from clifford.g3c import layout, e1, e2
+import clifford as cf
+
+
+@numba.njit
+def identity(x):
+    return x
+
+
+class TestBasic:
+    """ Test very simple construction and field access """
+
+    def test_roundtrip_layout(self):
+        layout_r = identity(layout)
+        assert type(layout_r) is type(layout)
+        assert layout_r is layout
+
+    def test_roundtrip_mv(self):
+        e1_r = identity(e1)
+        assert type(e1_r) is type(e1_r)
+
+        # mvs are values, and not preserved by identity
+        assert e1_r.layout is e1.layout
+        assert e1_r == e1
+
+    def test_piecewise_construction(self):
+        @numba.njit
+        def negate(a):
+            return cf.MultiVector(a.layout, -a.value)
+
+        n_e1 = negate(e1)
+        assert n_e1.layout is e1.layout
+        assert n_e1 == -e1
+
+        @numba.njit
+        def add(a, b):
+            return cf.MultiVector(a.layout, a.value + b.value)
+
+        ab = add(e1, e2)
+        assert ab == e1 + e2
+        assert ab.layout is e1.layout

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -41,3 +41,10 @@ class TestBasic:
         ab = add(e1, e2)
         assert ab == e1 + e2
         assert ab.layout is e1.layout
+
+    def test_constant_multivector(self):
+        @numba.njit
+        def add_e1(a):
+            return cf.MultiVector(a.layout, a.value + e1.value)
+
+        assert add_e1(e2) == e1 + e2


### PR DESCRIPTION
This implements the minimal operations to allow numba functions like:
```
@numba.njit
def wedge3(a, b, c):
    ret_value = omt_func(a.value, omt_func(b.value, c.value))
    return MultiVector(a.layout, ret_value)
```

This means we can drop all of our `func` / `val_func` duality (in a future commit).

This implementation contains some patterns that do not match the standard numba way of doing things. I've tried to add comments where we diverge.