### PR TITLE
TST: io: Use temporary files for testing

### DIFF
--- a/clifford/test/test_io.py
+++ b/clifford/test/test_io.py
@@ -1,11 +1,15 @@
-import unittest
-from clifford import *
-from clifford.g3c import *
-from clifford.tools.g3c import *
-from clifford.io import *
+import numpy as np
+
+from clifford import MVArray
+from clifford.g3c import layout
+from clifford.tools.g3c import random_point_pair, ConformalMVArray
+from clifford.io import (
+    read_ga_file, write_ga_file,
+    read_json_file, write_json_file
+)
 
 
-class TestParseMultivector(unittest.TestCase):
+class TestParseMultivector:
 
     def test_parse_multivector(self):
         A = layout.randomMV()
@@ -13,10 +17,10 @@ class TestParseMultivector(unittest.TestCase):
         np.testing.assert_almost_equal(A.value, B.value, 3)
 
 
-class TestHDF5BasicIO(unittest.TestCase):
+class TestHDF5BasicIO:
 
-    def test_write_and_read(self):
-        file_name = "test.ga"
+    def test_write_and_read(self, tmp_path):
+        file_name = str(tmp_path / "test.ga")
 
         basis_names = np.array(list(sorted(layout.basis_vectors.keys())), dtype=bytes)
 
@@ -30,8 +34,8 @@ class TestHDF5BasicIO(unittest.TestCase):
         np.testing.assert_equal(layout.metric, metric_2)
         np.testing.assert_equal(basis_names, basis_names_2)
 
-    def test_write_and_read_array(self):
-        file_name = "test.ga"
+    def test_write_and_read_array(self, tmp_path):
+        file_name = str(tmp_path / "test.ga")
 
         mv_array = MVArray([random_point_pair() for i in range(1000)])
         mv_array.save(file_name, compression=True, transpose=False, sparse=False, support=False)
@@ -41,10 +45,10 @@ class TestHDF5BasicIO(unittest.TestCase):
         np.testing.assert_equal(loaded_array.value, mv_array.value)
 
 
-class TestJSONBasicIO(unittest.TestCase):
+class TestJSONBasicIO:
 
-    def test_write_and_read(self):
-        file_name = "test.ga.json"
+    def test_write_and_read(self, tmp_path):
+        file_name = str(tmp_path / "test.ga.json")
 
         basis_names = np.array(list(sorted(layout.basis_vectors.keys())))
 
@@ -59,7 +63,7 @@ class TestJSONBasicIO(unittest.TestCase):
         np.testing.assert_equal(basis_names, basis_names_2)
 
     # def test_write_and_read_array(self):
-    #     file_name = "test.ga.json"
+    #     file_name = str(tmp_path / "test.ga.json")
     #
     #     mv_array = MVArray([random_point_pair() for i in range(1000)])
     #     mv_array.save(file_name, compression=True, transpose=False, sparse=False, support=False)
@@ -67,7 +71,3 @@ class TestJSONBasicIO(unittest.TestCase):
     #     loaded_array = layout.load_ga_file(file_name)
     #
     #     np.testing.assert_equal(loaded_array.value, mv_array.value)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ per-file-ignores =
     # This is caused by the import * for blades
     clifford/tools/g3c/*.py:F403,F405
     clifford/tools/g3/*.py:F403,F405
-    clifford/test/test_io.py:F403,F405
     clifford/test/test_g3c_tools.py:F403,F405
 
     # TODO: fix the ones here that aren't repeats of above


### PR DESCRIPTION
This avoids them being accidentally checked into git

Also remove the * imports and the flake8 config that permits them, for clarity