### PR TITLE
Make `conformalize` return a subclass of `Layout`.

### DIFF
--- a/clifford/_conformal_layout.py
+++ b/clifford/_conformal_layout.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+from ._layout import Layout
+from ._multivector import MultiVector
+
+
+class ConformalLayout(Layout):
+    r"""
+    A layout for a conformal algebra, which adds extra constants and helpers.
+
+    Typically these should be constructed via :func:`clifford.conformalize`.
+
+    Attributes
+    ----------
+    ep : MultiVector
+        The first added basis element, :math:`e_{+}`, usually with :math:`e_{+}^2 = +1`
+    en : MultiVector
+        The first added basis element, :math:`e_{-}`, usually with :math:`e_{-}^2 = -1`
+    eo : MultiVector
+        The null basis vector at the origin, :math:`e_o = 0.5(e_{-} - e_{+})`
+    einf : MultiVector
+        The null vector at infinity, :math:`e_\infty = e_{-} + e_{+}`
+    E0 : MultiVector
+        The minkowski subspace bivector, :math:`e_\infty \wedge e_o`
+    I_base : MultiVector
+        The pseudoscalar of the base ga, in cga layout
+    """
+    def __init__(self, *args, layout=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._base_layout = layout
+
+        basis_vectors = self.basis_vectors
+        added_keys = sorted(basis_vectors.keys())[-2:]
+        ep, en = [basis_vectors[k] for k in added_keys]
+
+        # setup  null basis, and minkowski subspace bivector
+        eo = .5 ^ (en - ep)
+        einf = en + ep
+        E0 = einf ^ eo
+        I_base = self.pseudoScalar*E0
+
+        # for compatibility
+        self.isconformal = True
+
+        # helper properties
+        self.ep = ep
+        self.en = en
+        self.eo = eo
+        self.einf = einf
+        self.E0 = E0
+        self.I_base = I_base
+
+    @classmethod
+    def _from_base_layout(cls, layout, added_sig=[1, -1], **kw) -> 'ConformalLayout':
+        """ helper to implement :func:`clifford.conformalize` """
+        sig_c = list(layout.sig) + added_sig
+        return cls._from_sig(sig=sig_c, firstIdx=layout.firstIdx, layout=layout, **kw)
+
+    # some convenience functions
+    def up(self, x: MultiVector) -> MultiVector:
+        """ up-project a vector from GA to CGA """
+        try:
+            if x.layout == self._base_layout:
+                # vector is in original space, map it into conformal space
+                old_val = x.value
+                new_val = np.zeros(self.gaDims)
+                new_val[:len(old_val)] = old_val
+                x = self.MultiVector(value=new_val)
+        except(AttributeError):
+            # if x is a scalar it doesnt have layout but following
+            # will still work
+            pass
+
+        # then up-project into a null vector
+        return x + (.5 ^ ((x**2)*self.einf)) + self.eo
+
+    def homo(self, x: MultiVector) -> MultiVector:
+        """ homogenize a CGA vector """
+        return x*(-x | self.einf)(0).normalInv()
+
+    def down(self, x: MultiVector) -> MultiVector:
+        """ down-project a vector from CGA to GA """
+        x_down = (self.homo(x) ^ self.E0)*self.E0
+        # new_val = x_down.value[:self.base_layout.gaDims]
+        # create vector in self.base_layout (not cga)
+        # x_down = self.base_layout.MultiVector(value=new_val)
+        return x_down

--- a/clifford/_conformal_layout.py
+++ b/clifford/_conformal_layout.py
@@ -39,9 +39,6 @@ class ConformalLayout(Layout):
         E0 = einf ^ eo
         I_base = self.pseudoScalar*E0
 
-        # for compatibility
-        self.isconformal = True
-
         # helper properties
         self.ep = ep
         self.en = en

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -157,6 +157,18 @@ class Layout(object):
         self.dual_func = self.gen_dual_func()
         self.vee_func = self.gen_vee_func()
 
+    @classmethod
+    def _from_sig(cls, sig=None, *, firstIdx=1, **kwargs):
+        """ Factory method that uses sorted blade tuples.  """
+        bladeTupList = cf.elements(len(sig), firstIdx)
+
+        return cls(sig, bladeTupList, firstIdx=firstIdx, **kwargs)
+
+    @classmethod
+    def _from_Cl(cls, p=0, q=0, r=0, **kwargs):
+        """ Factory method from a ${Cl}_{p,q,r}$ notation """
+        return cls._from_sig([0]*r + [+1]*p + [-1]*q, **kwargs)
+
     def __hash__(self):
         """ hashs the signature of the layout """
         return hash(tuple(self.sig))
@@ -197,10 +209,10 @@ class Layout(object):
         return self._newMV(constructed_values)
 
     def __repr__(self):
-        s = ("Layout(%r, %r, firstIdx=%r, names=%r)" % (
-                list(self.sig),
-                self.bladeTupList, self.firstIdx, self.names))
-        return s
+        return "{}({!r}, {!r}, firstIdx={!r}, names={!r})".format(
+            type(self).__name__,
+            list(self.sig), self.bladeTupList, self.firstIdx, self.names
+        )
 
     def __eq__(self, other):
         if other is self:

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -90,10 +90,6 @@ class Layout(object):
         corresponding list of the grades of each blade
     gaDims :
         2**dims
-    einf :
-        if conformal returns einf
-    eo :
-        if conformal returns eo
     names :
         pretty-printing symbols for the blades
     even :
@@ -125,10 +121,6 @@ class Layout(object):
         self.gradeList = list(map(len, self.bladeTupList))
 
         self._metric = None
-
-        self.isconformal = False
-        self.einf = None
-        self.eo = None
 
         if names is None or isinstance(names, str):
             if isinstance(names, str):

--- a/clifford/tools/point_processing.py
+++ b/clifford/tools/point_processing.py
@@ -1,7 +1,7 @@
 
 import scipy.spatial
 import numpy as np
-from .. import MVArray
+from .. import MVArray, ConformalLayout
 import itertools
 import scipy.special
 import random
@@ -39,7 +39,7 @@ class GADelaunay(scipy.spatial.Delaunay):
         """
         Returns the list of conformal points in each facet
         """
-        if self.layout.isconformal:
+        if isinstance(self.layout, ConformalLayout):
             return [[self.GApoints[i] for i in s] for s in self.simplices]
         else:
             raise ValueError('Input points do not seem to be from a conformal algebra')
@@ -72,7 +72,7 @@ class GAConvexHull(scipy.spatial.ConvexHull):
         """
         Returns the list of conformal points in each facet
         """
-        if self.layout.isconformal:
+        if isinstance(self.layout, ConformalLayout):
             return [[self.GApoints[i] for i in s] for s in self.simplices]
         else:
             raise ValueError('Input points do not seem to be from a conformal algebra')
@@ -82,7 +82,7 @@ class GAConvexHull(scipy.spatial.ConvexHull):
         Returns the conformal rounds made of the wedge
         product of the edge simplices
         """
-        if self.layout.isconformal:
+        if isinstance(self.layout, ConformalLayout):
             return [MVArray([self.GApoints[i] for i in s]).op().normal() for s in self.simplices]
         else:
             raise ValueError('Input points do not seem to be from a conformal algebra')
@@ -92,7 +92,7 @@ class GAConvexHull(scipy.spatial.ConvexHull):
         Returns the conformal flats made of the wedge
         product of the edge simplices with einf
         """
-        if self.layout.isconformal:
+        if isinstance(self.layout, ConformalLayout):
             return [(r^self.layout.einf).normal() for r in self.conformal_rounds()]
         else:
             raise ValueError('Input points do not seem to be from a conformal algebra')

--- a/docs/issues_and_changelog.rst
+++ b/docs/issues_and_changelog.rst
@@ -105,6 +105,15 @@ tests.
 ChangeLog
 =========
 
+Upcoming changes
+++++++++++++++++
+
+ * ``layout.isconformal``, ``layout.einf``, and ``layout.eo``, which were added
+   in 1.0.4, have been removed. The first can now be spelt
+   ``isinstance(layout, clifford.ConformalLayout)``, and the other properties
+   now exist only on :class:`ConformalLayout` objects.
+
+
 Changes in 1.1.0
 ++++++++++++++++
 


### PR DESCRIPTION
This means that `layout.up` and `layout.einf` etc are available, which makes it easier to write code that works for both g3c and g2c.

In order to make this change, most of the interesting logic in `Cl` and `conformalize` moved to private classmethods in `Layout` and `ConformalLayout`.
In future, we could consider making these methods public, and maybe deprecating the public ones.

Relates somewhat to #37 