### PR TITLE
Fixed bug in pow of 0

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -1300,7 +1300,8 @@ class MultiVector(object):
         other = int(round(other))
 
         if other == 0:
-            return 1
+            unit_out = self._newMV(dtype=self.value.dtype) + 1
+            return unit_out
 
         newMV = self._newMV(np.array(self.value))  # copy
 


### PR DESCRIPTION
Previously pow of 0 returned an object of type Int, making ~(R**0) give -2.