### PR TITLE
Remove the repeated member listings from autosummarized modules

### DIFF
--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,0 +1,6 @@
+.. our modules have docstrings that already list their members, so don't
+.. repeat the listing.
+
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}


### PR DESCRIPTION
Since our modules list their members in a structured way within their docstring, we do not need a repeated list of members at the bottom.

Unfortunately, we are not able to specify this template per-autosummary, due to the hack in our conf.py to generate autosummary directives recursively. It seems safe to perform the global override.