### PR TITLE
BUG: Fix layout.(o|i|lc)mt_func_generator

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -310,19 +310,19 @@ class Layout(object):
 
     def imt_func_generator(self, grades_a=None, grades_b=None, filter_mask=None):
         return get_mult_function(
-            self.gmt, self.gradeList,
+            self.imt, self.gradeList,
             grades_a=grades_a, grades_b=grades_b, filter_mask=filter_mask
         )
 
     def omt_func_generator(self, grades_a=None, grades_b=None, filter_mask=None):
         return get_mult_function(
-            self.gmt, self.gradeList,
+            self.omt, self.gradeList,
             grades_a=grades_a, grades_b=grades_b, filter_mask=filter_mask
         )
 
     def lcmt_func_generator(self, grades_a=None, grades_b=None, filter_mask=None):
         return get_mult_function(
-            self.gmt, self.gradeList,
+            self.lcmt, self.gradeList,
             grades_a=grades_a, grades_b=grades_b, filter_mask=filter_mask
         )
 


### PR DESCRIPTION
This typo was introduced in 8dff5e977e2466df368dcc49e3de77d604a93aa5