### PR TITLE
Fix azure config so that pytest is new enough to provide a tmp_path fixture

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,6 +157,7 @@ jobs:
 
   - script: |
       call activate myEnvironment
+      pip install -U pytest  # the pytest in conda for python 3.5 is too old
       pytest clifford/test --doctest-modules --junitxml=junit/test-results.xml
     displayName: pytest windows
     condition: eq(variables['imageName'], 'vs2017-win2016')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,7 +157,7 @@ jobs:
 
   - script: |
       call activate myEnvironment
-      pip install -U pytest  # the pytest in conda for python 3.5 is too old
+      pip install -U pytest
       pytest clifford/test --doctest-modules --junitxml=junit/test-results.xml
     displayName: pytest windows
     condition: eq(variables['imageName'], 'vs2017-win2016')


### PR DESCRIPTION
All of the azure 3.5 runs were failing because of this.