### PR TITLE
Fix deployment to only run if tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,52 @@
+# there is nothing special about this key, it's just ignored by travis
+x-clifford-templates:
+  lint_job: &lint_job
+    install:
+      - pip install flake8
+      - python setup.py install
+    script: flake8 clifford
 
-sudo: false
+  test_job: &test_job
+    install:
+      - |
+        if [[ "${CONDA}" == "true" ]]; then
+          PYTHON_VERSION="$TRAVIS_PYTHON_VERSION" CONDA_INSTALLER_OS="${TRAVIS_OS_NAME:-linux}" source auto_version/travis_install_conda.sh \
+            numpy \
+            scipy \
+            numba \
+            pip \
+            h5py \
+            pytest \
+            pytest-cov;
+          conda install -c conda-forge sparse;
+          conda install -c numba numba==0.45.1;
+        else
+          pip install pytest-cov
+        fi
+      - python setup.py install
+      - pip install codecov
+    script:
+      - |
+        pytest clifford/test \
+          --doctest-modules \
+          --junitxml=junit/test-results.xml \
+          --durations=25 \
+          --cov=clifford \
+          --cov-branch
+    after_success:
+      - codecov
+
+  deploy_job: &deploy_job
+    install: skip
+    script: skip
+    deploy:
+      provider: pypi
+      user: arsenovic
+      distributions: "sdist bdist_wheel"
+      password:
+        secure: ieUd3c2DjrZQE+3FlqmU5FQObNWIDiL9E9G6aLs0ksEKAi5Z1t7fefXic1XHsHOZZYteycef/lZkUYg3ijwfZg2xzELeTdLef29GgUrxYuGL4MJ706UFj450Xlv9l1oH5D32OEKT2EwfxMqdrw39+N8zD5ehVyQbYM6Z3lwtCvg=
+      on:
+        tags: true
 
 language: python
 
@@ -9,61 +56,30 @@ matrix:
       python: '3.6'
       script: flake8 clifford
       stage: Lint
+      <<: *lint_job
+
     - os: linux
       python: '3.5'
       env: CONDA=false
       stage: Test
+      <<: *test_job
     - os: linux
       python: '3.6'
       env: CONDA=false
       stage: Test
+      <<: *test_job
     - os: linux
       python: '3.5'
       env: CONDA=true
       stage: Test
+      <<: *test_job
     - os: linux
       python: '3.6'
       env: CONDA=true
       stage: Test
+      <<: *test_job
 
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then lsb_release -a ; fi
-
-install:
-  - |
-    if [[ "${CONDA}" == "true" ]]; then
-      PYTHON_VERSION="$TRAVIS_PYTHON_VERSION" CONDA_INSTALLER_OS="${TRAVIS_OS_NAME:-linux}" source auto_version/travis_install_conda.sh \
-        numpy \
-        scipy \
-        numba \
-        pip \
-        h5py \
-        pytest \
-        pytest-cov;
-      conda install -c conda-forge sparse;
-      conda install -c numba numba==0.45.1;
-    else
-      pip install pytest-cov flake8
-    fi
-  - python setup.py install
-  - pip install codecov
-
-script:
-  - |
-    pytest clifford/test \
-      --doctest-modules \
-      --junitxml=junit/test-results.xml \
-      --durations=25 \
-      --cov=clifford \
-      --cov-branch
-
-after_success:
-  - codecov
-
-deploy:
-  provider: pypi
-  user: arsenovic
-  password:
-    secure: ieUd3c2DjrZQE+3FlqmU5FQObNWIDiL9E9G6aLs0ksEKAi5Z1t7fefXic1XHsHOZZYteycef/lZkUYg3ijwfZg2xzELeTdLef29GgUrxYuGL4MJ706UFj450Xlv9l1oH5D32OEKT2EwfxMqdrw39+N8zD5ehVyQbYM6Z3lwtCvg=
-  on:
-    tags: true
+    - os: linux
+      python: '3.6'
+      stage: Deploy
+      <<: *deploy_job


### PR DESCRIPTION
This also releases a pure-python wheel, just in case that's convenient for some users

This change takes advantage of the yaml features described [here](https://medium.com/@kinghuang/docker-compose-anchors-aliases-extensions-a1e4105d70bd)

Note that this removes `sudo: true`, which travis ignores anyway\

Closes #179, closes #96