### PR TITLE
Fix a numba deprecation warning

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -370,7 +370,7 @@ def grade_obj(objin, threshold=0.0000001):
     '''
     Returns the modal grade of a multivector
     '''
-    return grade_obj_func(objin.value, objin.layout.gradeList, threshold)
+    return grade_obj_func(objin.value, np.asarray(objin.layout.gradeList), threshold)
 
 
 def grades_present(objin: 'MultiVector', threshold=0.0000001) -> Set[int]:


### PR DESCRIPTION
The `grade_obj` function was giving this warning:
```
  /home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/numba-0.45.1-py3.6-linux-x86_64.egg/numba/ir_utils.py:1959: NumbaPendingDeprecationWarning:
  Encountered the use of a type that is scheduled for deprecation: type 'reflected list' found for argument 'gradeList' of function 'grade_obj_func'.

  For more information visit http://numba.pydata.org/numba-doc/latest/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types

  File "clifford/__init__.py", line 295:
  @numba.njit
  def grade_obj_func(objin_val, gradeList, threshold):
  ^

    warnings.warn(NumbaPendingDeprecationWarning(msg, loc=loc))
```