### PR TITLE
Add _repr_pretty_ to `layout`

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -206,6 +206,21 @@ class Layout(object):
             list(self.sig), self.bladeTupList, self.firstIdx, self.names
         )
 
+    def _repr_pretty_(self, p, cycle):
+        if cycle:
+            raise RuntimeError("Should not be cyclic")
+
+        prefix = '{}('.format(type(self).__name__)
+
+        with p.group(len(prefix), prefix, ')'):
+            p.text('{},'.format(list(self.sig)))
+            p.breakable()
+            p.text('{},'.format(list(self.bladeTupList)))
+            p.breakable()
+            p.text('names={},'.format(self.names))
+            p.breakable()
+            p.text('firstIdx={}'.format(self.firstIdx))
+
     def __eq__(self, other):
         if other is self:
             return True


### PR DESCRIPTION
This makes the output in Jupyter a little less ugly:
```
ConformalLayout([1, 1, 1, 1, -1],
                [(), (1,), (2,), (3,), (4,), (5,), (1, 2), (1, 3), (1, 4), (1, 5), (2, 3), (2, 4), (2, 5), (3, 4), (3, 5), (4, 5), (1, 2, 3), (1, 2, 4), (1, 2, 5), (1, 3, 4), (1, 3, 5), (1, 4, 5), (2, 3, 4), (2, 3, 5), (2, 4, 5), (3, 4, 5), (1, 2, 3, 4), (1, 2, 3, 5), (1, 2, 4, 5), (1, 3, 4, 5), (2, 3, 4, 5), (1, 2, 3, 4, 5)],
                names=['', 'e1', 'e2', 'e3', 'e4', 'e5', 'e12', 'e13', 'e14', 'e15', 'e23', 'e24', 'e25', 'e34', 'e35', 'e45', 'e123', 'e124', 'e125', 'e134', 'e135', 'e145', 'e234', 'e235', 'e245', 'e345', 'e1234', 'e1235', 'e1245', 'e1345', 'e2345', 'e12345'],
                firstIdx=1])
```