### PR TITLE
Add pretty-printing to `classify.Blade` objects

### DIFF
--- a/clifford/tools/classify.py
+++ b/clifford/tools/classify.py
@@ -237,6 +237,21 @@ class Blade(metaclass=_GradedTypesMeta):
             "{}={!r}".format(k, v) for k, v in members.items()
         ))
 
+    def _repr_pretty_(self, p, cycle):
+        members = self.__dict__.copy()
+        for name in self._repr_skip_members():
+            members.pop(name)
+
+        prefix = '{}('.format(type(self).__name__)
+        with p.group(len(prefix), prefix, ')'):
+            is_first = True
+            for k, v in members.items():
+                if not is_first:
+                    p.text(',')
+                    p.breakable()
+                p.text("{}={!r}".format(k, v))
+                is_first = False
+
     def _translate(self, t, x):
         """ Internal helper to translate x (conformal) by t (euclidean vector) """
         einf = self.layout.einf


### PR DESCRIPTION
This makes the output line-wrap nicely:
```
Circle(location=(0.5^e1) + (1.0^e2) + (0.5^e3),
       radius=0.7071067811865476,
       direction=(1.0^e13))
```