### PR TITLE
Correct the sign of the vee product 

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -183,11 +183,15 @@ class Layout(object):
         """
         Generates the vee product function
         """
-        dual_func = self.dual_func
+        # Often, the dual and undual are used here. However, this unecessarily
+        # invokes the metric for a product that is itself non-metric. The
+        # complement functions are faster anyway.
+        rc_func = self.right_complement_func
+        lc_func = self.left_complement_func
         omt_func = self.omt_func
         @numba.njit
         def vee(aval, bval):
-            return dual_func(omt_func(dual_func(aval), dual_func(bval)))
+            return lc_func(omt_func(rc_func(aval), rc_func(bval)))
         return vee
 
     @property

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -145,8 +145,8 @@ class Layout(object):
 
         self._genTables()
         self.adjoint_func = get_adjoint_function(self.gradeList)
-        self.right_complement_func = self._gen_complement_func(wedge=lambda a, b: a^b)
-        self.left_complement_func = self._gen_complement_func(wedge=lambda a, b: b^a)
+        self.left_complement_func = self._gen_complement_func(wedge=lambda a, b: a^b)
+        self.right_complement_func = self._gen_complement_func(wedge=lambda a, b: b^a)
         self.dual_func = self.gen_dual_func()
         self.vee_func = self.gen_vee_func()
 

--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -237,6 +237,9 @@ class MultiVector(object):
     def right_complement(self) -> 'MultiVector':
         return self.layout.MultiVector(value=self.layout.right_complement_func(self.value))
 
+    def left_complement(self) -> 'MultiVector':
+        return self.layout.MultiVector(value=self.layout.left_complement_func(self.value))
+
     def __truediv__(self, other) -> 'MultiVector':
         """Division, :math:`M N^{-1}`"""
 

--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -97,15 +97,26 @@ class MultiVector(object):
         return general_exp(self)
 
     def vee(self, other) -> 'MultiVector':
-        """
-        The vee product aka. the meet... To be optimised still
+        r"""
+        Vee product :math:`A \vee B`.
+
+        This is often defined as:
+
+        .. math::
+            `(A \vee B)^* &= A^* \wedge B^*`
+            \implies A \vee B &= (A^* \wedge B^*)^{-*}
+
+        This is very similar to the :meth:`~MultiVector.meet` function, but
+        always uses the dual in the full space .
+
+        Internally, this is actually implemented using the complement
+        functions instead, as these work in degenerate metrics like PGA too,
+        and are equivalent but faster in other metrics.
         """
         return self.layout.MultiVector(value=self.layout.vee_func(self.value, other.value))
 
     def __and__(self, other) -> 'MultiVector':
-        """
-        The vee product aka. the meet... To be optimised still
-        """
+        """ Alias for :meth:`~MultiVector.vee` """
         return self.vee(other)
 
     def __mul__(self, other) -> 'MultiVector':

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -357,6 +357,25 @@ class TestBasicConformal41:
         assert (e4 * e4)[0] == 1
         assert (e5 * e5)[0] == -1
 
+    def test_vee(self):
+        layout_a = Cl(3)[0]
+        layout, blades, stuff = conformalize(layout_a)
+        e1 = layout.blades['e1']
+        e2 = layout.blades['e2']
+        e3 = layout.blades['e3']
+        up = layout.up
+
+        A = up(e1)
+        B = up(e2)
+        C = up(-e1)
+        D = up(e3)
+
+        sph = A^B^C^D
+        pl = A^B^C^layout.einf
+
+        assert sph & pl == 2*(A^B^C)
+        assert pl & sph == -2*(A^B^C)
+
     def test_factorise(self):
         layout_a = Cl(3)[0]
         layout, blades, stuff = conformalize(layout_a)

--- a/clifford/test/test_degenerate.py
+++ b/clifford/test/test_degenerate.py
@@ -9,14 +9,12 @@ class TestPGA:
     layout, _ = Cl(3, 0, 1, firstIdx=0)
 
     def test_right_complement(self):
-        # TODO[gh-216]: Does this mean we implemented the left complement?
         for b in self.layout.blades_list:
-            assert b.right_complement() ^ b == self.layout.pseudoScalar
+            assert b ^ b.right_complement() == self.layout.pseudoScalar
 
     def test_left_complement(self):
-        # TODO[gh-216]: Does this mean we implemented the right complement?
         for b in self.layout.blades_list:
-            assert b ^ b.left_complement() == self.layout.pseudoScalar
+            assert b.left_complement() ^ b == self.layout.pseudoScalar
 
     def test_vee(self):
         blades = self.layout.blades

--- a/clifford/test/test_degenerate.py
+++ b/clifford/test/test_degenerate.py
@@ -11,7 +11,12 @@ class TestPGA:
     def test_right_complement(self):
         # TODO[gh-216]: Does this mean we implemented the left complement?
         for b in self.layout.blades_list:
-            assert b.right_complement() * b == self.layout.pseudoScalar
+            assert b.right_complement() ^ b == self.layout.pseudoScalar
+
+    def test_left_complement(self):
+        # TODO[gh-216]: Does this mean we implemented the right complement?
+        for b in self.layout.blades_list:
+            assert b ^ b.left_complement() == self.layout.pseudoScalar
 
     def test_no_crash(self):
         """ TODO: This doesn't actually do any asserts! """

--- a/clifford/test/test_degenerate.py
+++ b/clifford/test/test_degenerate.py
@@ -18,6 +18,36 @@ class TestPGA:
         for b in self.layout.blades_list:
             assert b ^ b.left_complement() == self.layout.pseudoScalar
 
+    def test_vee(self):
+        blades = self.layout.blades
+
+        e0 = blades['e0']
+        e1 = blades['e1']
+        e2 = blades['e2']
+        e3 = blades['e3']
+
+        e01 = blades['e01']
+        e02 = blades['e02']
+        e03 = blades['e03']
+        e12 = blades['e12']
+        e13 = blades['e13']
+        e23 = blades['e23']
+
+        e123 = e1^e2^e3
+        e032 = e0^e3^e2
+        e013 = e0^e1^e3
+        e021 = e0^e2^e1
+
+        # PGA points are trivectors.
+        # A point is just a homogeneous point, euclidean coordinates plus the origin
+        def POINT(x, y, z):
+            return e123 + x*e032 + y*e013 + z*e021
+
+        P1 = POINT(0, 0, 1)
+        P2 = POINT(3, 4, 0)
+        L = P1 & P2
+        assert L == -(4^e01) + (3^e02) - (1^e12) - (4^e13) + (3^e23)
+
     def test_no_crash(self):
         """ TODO: This doesn't actually do any asserts! """
         layout = self.layout

--- a/docs/issues_and_changelog.rst
+++ b/docs/issues_and_changelog.rst
@@ -112,6 +112,8 @@ Changes in 1.2.x
    in 1.0.4, have been removed. The first can now be spelt
    ``isinstance(layout, clifford.ConformalLayout)``, and the other properties
    now exist only on :class:`ConformalLayout` objects.
+ * :meth:`MultiVector.vee` has been corrected to have the same sign as
+   :meth:`MultiVector.meet`.
  * :meth:`MultiVector.left_complement` has been added to match
    :meth:`MultiVector.right_complement`.
 

--- a/docs/issues_and_changelog.rst
+++ b/docs/issues_and_changelog.rst
@@ -112,6 +112,8 @@ Changes in 1.2.x
    in 1.0.4, have been removed. The first can now be spelt
    ``isinstance(layout, clifford.ConformalLayout)``, and the other properties
    now exist only on :class:`ConformalLayout` objects.
+ * :meth:`MultiVector.left_complement` has been added to match
+   :meth:`MultiVector.right_complement`.
 
 
 Changes in 1.1.x

--- a/docs/issues_and_changelog.rst
+++ b/docs/issues_and_changelog.rst
@@ -113,9 +113,9 @@ Changes in 1.2.x
    ``isinstance(layout, clifford.ConformalLayout)``, and the other properties
    now exist only on :class:`ConformalLayout` objects.
  * :meth:`MultiVector.vee` has been corrected to have the same sign as
-   :meth:`MultiVector.meet`.
- * :meth:`MultiVector.left_complement` has been added to match
-   :meth:`MultiVector.right_complement`.
+   :meth:`MultiVector.meet`
+ * :meth:`MultiVector.right_complement` no longer performs the left complement.
+ * :meth:`MultiVector.left_complement` has been added for when this was intended.
 
 
 Changes in 1.1.x


### PR DESCRIPTION
This uses the complement functions instead of the dual, which is faster.

Additionally, it uses an equivalent of "undual" as the final step, which makes the sign correct