### PR TITLE
Fix issues with old pytest version in conda CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,12 @@ x-clifford-templates:
             scipy \
             numba \
             pip \
-            h5py \
-            pytest \
-            pytest-cov;
+            h5py;
           conda install -c conda-forge sparse;
           conda install -c numba numba==0.45.1;
-        else
-          pip install pytest-cov
         fi
+      # always install with pip, conda has too old a version
+      - pip install pytest pytest-cov
       - python setup.py install
       - pip install codecov
     script:


### PR DESCRIPTION
This was already fixed for azure in 364c09c8af4eb1b3755ca4cbcc325c66dbd2bcd2, but seems to have come back for travis.