### PR TITLE
Move gp, op, and ip to a new `clifford.operator` module

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -56,6 +56,9 @@ from clifford.io import write_ga_file, read_ga_file  # noqa: F401
 
 from ._version import __version__  # noqa: F401
 
+# For backwards-compatibility. New code should import directly from `clifford.operator`
+from .operator import gp, op, ip  # noqa: F401
+
 _eps = 1e-12            # float epsilon for float comparisons
 _pretty = True          # pretty-print global
 _print_precision = 5    # pretty printing precision on floats
@@ -848,57 +851,6 @@ def print_precision(newVal):
 
     global _print_precision
     _print_precision = newVal
-
-
-def gp(M, N):
-    """
-    Geometric product
-
-    gp(M, N) =  M * N
-
-    M and N must be from the same layout
-
-    This is useful in calculating series of products, with `reduce()`
-    for example
-
-    >>>Ms = [M1, M2, M3] # list of multivectors
-    >>>reduce(gp, Ms) #  == M1*M2*M3
-
-    """
-
-    return M*N
-
-
-def ip(M, N):
-    """
-    Inner product function
-
-    ip(M, N) =  M | N
-
-    M and N must be from the same layout
-
-    """
-
-    return M ^ N
-
-
-def op(M, N):
-    """
-    Outer product function
-
-    op(M, N) =  M ^ N
-
-    M and N must be from the same layout
-
-    This is useful in calculating series of products, with `reduce()`
-    for example
-
-    >>>Ms = [M1, M2, M3] # list of multivectors
-    >>>reduce(op, Ms) #  == M1^M2^M3
-
-    """
-
-    return M ^ N
 
 
 def conformalize(layout, added_sig=[1, -1], *, mvClass=MultiVector, **kwargs):

--- a/clifford/operator.py
+++ b/clifford/operator.py
@@ -1,0 +1,48 @@
+"""
+.. currentmodule:: clifford.operator
+
+=============================================
+operator functions (:mod:`clifford.operator`)
+=============================================
+
+This module exists to enable functional programming via :func:`functools.reduce`.
+It can be thought of as equivalent to the builtin :mod:`operator` module, but for the operators from geometric algebra.
+
+    >>> import functools
+    >>> import clifford.operator
+    >>> Ms = [M1, M2, M3] # list of multivectors
+    >>> assert functools.reduce(clifford.operator.op, Ms) == M1 ^ M2 ^ M3
+
+.. autofunction:: gp
+
+.. autofunction:: op
+
+.. autofunction:: ip
+
+"""
+def gp(M, N):
+    """
+    Geometric product function :math:`MN`, equivalent to ``M * N``.
+
+    M and N must be from the same layout
+    """
+
+    return M * N
+
+
+def ip(M, N):
+    r"""
+    Hestenes inner product function :math:`M \bullet N`, equivalent to ``M | N``.
+
+    M and N must be from the same layout
+    """
+    return M | N
+
+
+def op(M, N):
+    r"""
+    Outer product function :math:`M \wedge N`, equivalent to ``M ^ N``.
+
+    M and N must be from the same layout
+    """
+    return M ^ N

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,12 +1,11 @@
 API
 ------
 
-    
+
 .. toctree::
     :maxdepth: 1
-    
+
     clifford
     cga
     tools
-
-
+    operator


### PR DESCRIPTION
The primary goal here is to make them easier to document (they previously were not documented at all).
The names are still perfectly usable from the old location.

Also, fix the `ip` to be the inner product and not the outer product.

![image](https://user-images.githubusercontent.com/425260/75115871-b449c400-565a-11ea-8dad-9361fad6385d.png)
