### PR TITLE
Make `cf.ugly()` less ugly

### DIFF
--- a/clifford/g2.py
+++ b/clifford/g2.py
@@ -1,4 +1,7 @@
-
 from . import Cl
 layout, blades = Cl(2)
 locals().update(blades)
+
+# for shorter reprs
+layout.__name__ = 'layout'
+layout.__module__ = __name__

--- a/clifford/g2c.py
+++ b/clifford/g2c.py
@@ -5,3 +5,7 @@ layout, blades, stuff = conformalize(layout_orig)
 
 locals().update(blades)
 locals().update(stuff)
+
+# for shorter reprs
+layout.__name__ = 'layout'
+layout.__module__ = __name__

--- a/clifford/g3.py
+++ b/clifford/g3.py
@@ -1,3 +1,7 @@
 from . import Cl
 layout, blades = Cl(3)
 locals().update(blades)
+
+# for shorter reprs
+layout.__name__ = 'layout'
+layout.__module__ = __name__

--- a/clifford/g3c.py
+++ b/clifford/g3c.py
@@ -5,3 +5,7 @@ layout, blades, stuff = conformalize(layout_orig)
 
 locals().update(blades)
 locals().update(stuff)
+
+# for shorter reprs
+layout.__name__ = 'layout'
+layout.__module__ = __name__

--- a/clifford/gac.py
+++ b/clifford/gac.py
@@ -2,6 +2,10 @@ from . import Cl
 layout, blades = Cl(5, 3)
 locals().update(blades)
 
+# for shorter reprs
+layout.__name__ = 'layout'
+layout.__module__ = __name__
+
 n1 = e3 + e6
 n2 = e4 + e7
 n3 = e5 + e8

--- a/clifford/pga.py
+++ b/clifford/pga.py
@@ -2,3 +2,7 @@ from . import Cl
 
 layout, blades = Cl(3, 0, 1, firstIdx=0)
 locals().update(blades)
+
+# for shorter reprs
+layout.__name__ = 'layout'
+layout.__module__ = __name__


### PR DESCRIPTION
This adds three helpful changes:

* The `layout` objects of predefined algebras define `.__name__` and `.__module__` so that they can be printed more succintly
* `MultiVector.__repr__` now uses these attributes in ugly mode
* In ugly mode, ipython uses `MuiltiVector._repr_pretty_`, which wraps lines in a more readable way

Demo below:

```python
In [1]: from clifford.g3c import *

In [2]: e1
Out[2]: (1^e1)

In [3]: import clifford; clifford.ugly()

# named layout
In [4]: e1
Out[4]:
clifford.g3c.layout.MultiVector([0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                dtype('int32'))

# unnamed layout
In [5]: layout_orig.blades['e1'] * 1.0
Out[5]:
MultiVector(Layout([1, 1, 1],
                   [(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)],
                   names=['', 'e1', 'e2', 'e3', 'e12', 'e13', 'e23', 'e123'],
                   firstIdx=1),
            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
```