### PR TITLE
Add links to docs at the top of every notebook

### DIFF
--- a/docs/tutorials/InterfacingOtherMathSystems.ipynb
+++ b/docs/tutorials/InterfacingOtherMathSystems.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Interfacing Other Mathematical Systems\n"

--- a/docs/tutorials/PerformanceCliffordTutorial.ipynb
+++ b/docs/tutorials/PerformanceCliffordTutorial.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Writing high(ish) performance code with Clifford and Numba via Numpy\n",

--- a/docs/tutorials/cga/clustering.ipynb
+++ b/docs/tutorials/cga/clustering.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Example 2 Clustering Geometric Objects"

--- a/docs/tutorials/cga/index.ipynb
+++ b/docs/tutorials/cga/index.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Conformal Geometric Algebra"

--- a/docs/tutorials/cga/interpolation.ipynb
+++ b/docs/tutorials/cga/interpolation.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Example 1 Interpolating Conformal Objects"

--- a/docs/tutorials/cga/object-oriented.ipynb
+++ b/docs/tutorials/cga/object-oriented.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Object Oriented CGA "

--- a/docs/tutorials/cga/robotic-manipulators.ipynb
+++ b/docs/tutorials/cga/robotic-manipulators.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Application to Robotic Manipulators\n",

--- a/docs/tutorials/cga/visualization-tools.ipynb
+++ b/docs/tutorials/cga/visualization-tools.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Visualization tools\n",

--- a/docs/tutorials/euler-angles.ipynb
+++ b/docs/tutorials/euler-angles.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Rotations in Space: Euler Angles, Matrices, and Quaternions"

--- a/docs/tutorials/g2-quick-start.ipynb
+++ b/docs/tutorials/g2-quick-start.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Quick Start   (G2)"

--- a/docs/tutorials/g3-algebra-of-space.ipynb
+++ b/docs/tutorials/g3-algebra-of-space.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# The  Algebra Of Space (G3)"

--- a/docs/tutorials/space-time-algebra.ipynb
+++ b/docs/tutorials/space-time-algebra.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `clifford` documentation: https://clifford.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#  Space Time Algebra "


### PR DESCRIPTION
Doing this means that people downloading individual notebooks can get back to the online docs.

These cells will not appear in the web docs.

Copied from the nbsphinx docs, which use the same tricks.