### PR TITLE
Move around requirements.txt files to satisfy binder.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,10 @@
 # extra requiremenets needed by the docs themselves
 # numpydoc==0.4
-ipython
-matplotlib
-mpl_toolkits.clifford>=0.0.3
-sphinx>=2.4
 ipykernel
 nbsphinx
-pyganja
-sphinx_rtd_theme
 ipywidgets
+sphinx>=2.4
+sphinx_rtd_theme
+numba > 0.45.1  # seemed to cause issues with sparse
+
+-r ../requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-numpy
-scipy
-numba==0.45.1
-h5py
+# These dependencies are directly imported by the notebooks themselves.
+# This is at the root so that binder can find it.
+# The doc build references this file.
+ipython
+matplotlib
+mpl_toolkits.clifford>=0.0.3
+pyganja

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         'numpy',
         'scipy',
-        'numba>=0.45.1',
+        'numba > 0.46',
         'h5py',
         'sparse',
     ],


### PR DESCRIPTION
It seems that binder is pinned on a bad numba version.
Additionally, it is missing the pyganja and mpl_toolkits.clifford dependency.

Two things to check here;

* Docs still can import `pyganja`
* Binder works (try http://mybinder.org/v2/gh/eric-wieser/clifford/fix-requirements.txt?filepath=docs/tutorials/cga/visualization-tools.ipynb)