### PR TITLE
Don't allow nonsense like `v[e1 + e12]`

### DIFF
--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -394,7 +394,10 @@ class MultiVector(object):
         value = M[index]
         """
         if isinstance(key, MultiVector):
-            return self.value[int(np.where(key.value)[0][0])]
+            inds, = np.nonzero(key.value)
+            if len(inds) > 1:
+                raise ValueError("Must be a single basis element")
+            return self.value[inds[0]]
         elif key in self.layout.bladeTupMap.keys():
             return self.value[self.layout.bladeTupMap[key]]
         elif isinstance(key, tuple):

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -169,6 +169,8 @@ class TestClifford:
         e3 = blades['e3']
         assert e12[e12] == 1
         assert e12[e3] == 0
+        with pytest.raises(ValueError):
+            e12[1 + e12]
         assert e12[(2, 1)] == -1
 
     def test_add_float64(self, g3):


### PR DESCRIPTION
Previously this would only return the lexicographically first basis element if multiple bases were passed in.