### PR TITLE
Remove `del mv[(1,)]`

### DIFF
--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -418,21 +418,6 @@ class MultiVector(object):
         else:
             self.value[key] = value
 
-    def __delitem__(self, key) -> None:
-        """Set the selected coefficient to 0.
-
-        del M[blade]
-        del M[index]
-        """
-
-        if key in self.layout.bladeTupMap.keys():
-            self.value[self.layout.bladeTupMap[key]] = 0
-        elif isinstance(key, tuple):
-            sign, blade = self.layout._compute_reordering_sign_and_canonical_form(key)
-            self.value[self.layout.bladeTupMap[blade]] = 0
-        else:
-            self.value[key] = 0
-
     # grade projection
     def __call__(self, other, *others) -> 'MultiVector':
         """Return a new multi-vector projected onto a grade OR a MV


### PR DESCRIPTION
This isn't what the `del` operator is for, and is more clear as `mv[(1,)] = 0` anyway.
`del` is used to remove an entry from a sequence -but this is neither a sequence, nor is setting to 0 the same as removing.

None of our docs or examples appear to use this.

---

If we're worried about this breaking someone, we could deprecate it instead - but I'd be surprised if anyone uses this.