### PR TITLE
Add tests for ipython pretty-printing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,12 @@ x-clifford-templates:
             scipy \
             numba \
             pip \
+            IPython \
             h5py;
           conda install -c conda-forge sparse;
           conda install -c numba numba>=0.45.1;
+        else
+          pip install IPython;
         fi
       # make sure in conda we do not overwrite dependencies with pip
       - |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,7 @@ jobs:
 
   - script: |
       call activate myEnvironment
-      conda install --yes python=$(python.version) h5py pytest setuptools scipy numpy
+      conda install --yes python=$(python.version) h5py pytest setuptools scipy numpy IPython
       conda install --yes -c conda-forge sparse
       conda install --yes $(numbacommand)
     displayName: Install dependencies windows
@@ -139,7 +139,7 @@ jobs:
       source activate myEnvironment
       conda update -n base -y -c defaults conda
       conda update -y conda
-      conda install --yes python=$(python.version) h5py pytest setuptools scipy numpy
+      conda install --yes python=$(python.version) h5py pytest setuptools scipy numpy IPython
       conda install --yes -c conda-forge sparse
       conda install --yes $(numbacommand)
       python -m pip install -U pytest pytest-benchmark

--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -541,7 +541,7 @@ class MultiVector(object):
             if self.value.dtype != np.float64:
                 p.text(",")
                 p.breakable()
-                p.pretty(self.value.dtype)
+                p.text("dtype={}".format(self.value.dtype))
 
     def __bool__(self) -> bool:
         """Instance is nonzero iff at least one of the coefficients is nonzero.


### PR DESCRIPTION
This feature was added a little while ago, but without tests.
Also tweaks the printing behavior slightly to more closely match the `repr`, using `str(dtype)` instead of `repr(dtype)`.