### PR TITLE
Improve the startup time by avoiding `inv()` to define `dual`.

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -363,7 +363,13 @@ class Layout(object):
             # We are degenerate, use the right complement
             return self.right_complement_func
         else:
-            Iinv = self.pseudoScalar.inv().value
+            # Equivalent to but faster than
+            #   Iinv = self.pseudoScalar.inv().value
+            Iinv = np.zeros(self.gaDims)
+            II_scalar = self.gmt[-1, 0, -1]
+            # set the pseudo-scalar part
+            Iinv[-1] = 1 / II_scalar
+
             gmt_func = self.gmt_func
             @_numba_utils.njit
             def dual_func(Xval):


### PR DESCRIPTION
Since the pseudoscalar squared is always a scalar, and that scalar is in a corner of the multiplication table, we can avoid having to perform any compilation.
Note that this just punts startup time from import to the first use of multiplication.