### PR TITLE
Deprecate clifford.grades_present

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -64,6 +64,7 @@ Miscellaneous functions
 # Standard library imports.
 import os
 import itertools
+import warnings
 from typing import List, Tuple, Set, Container, Dict, Optional
 
 # Major library imports.
@@ -261,15 +262,12 @@ def grade_obj(objin, threshold=0.0000001):
 
 
 def grades_present(objin: 'MultiVector', threshold=0.0000001) -> Set[int]:
-    '''
-    Returns all the grades of a multivector with coefficient magnitude bigger than threshold
-    '''
-    nonzero = abs(objin.value) > threshold
-    return {
-        grade_i
-        for grade_i, nonzero_i in zip(objin.layout.gradeList, nonzero)
-        if nonzero_i
-    }
+    # for backwards compatibility
+    warnings.warn(
+        "`clifford.grades_present(x)` is deprecated, use `x.grades()` instead. "
+        "Note that the method uses `clifford.eps()` as the default tolerance.",
+        DeprecationWarning, stacklevel=2)
+    return objin.grades(eps=threshold)
 
 
 # todo: work out how to let numba use the COO objects directly

--- a/clifford/test/test_g3c_tools.py
+++ b/clifford/test/test_g3c_tools.py
@@ -9,7 +9,7 @@ from numpy import exp
 import pytest
 import numba
 
-from clifford import Cl, grades_present
+from clifford import Cl
 from clifford.g3c import *
 from clifford import general_exp
 from clifford.tools.g3c import *
@@ -280,7 +280,7 @@ class TestG3CTools:
             X1 = obj_gen()
             basis, scale = X1.factorise()
             for b in basis:
-                gpres = grades_present(b, 0.0001)
+                gpres = b.grades(eps=0.0001)
                 assert gpres == {1}
             new_blade = (reduce(lambda a, b: a ^ b, basis) * scale)
             try:

--- a/clifford/tools/g3c/__init__.py
+++ b/clifford/tools/g3c/__init__.py
@@ -159,7 +159,7 @@ from clifford.tools.g3 import quaternion_to_rotor, random_euc_mv, \
     random_rotation_rotor, generate_rotation_rotor, val_random_euc_mv
 from clifford.g3c import *
 import clifford as cf
-from clifford import grades_present, NUMBA_PARALLEL, MVArray
+from clifford import NUMBA_PARALLEL, MVArray
 from scipy.interpolate import interp1d
 
 try:
@@ -223,7 +223,7 @@ def interpret_multivector_as_object(mv):
     Similar to :func:`clifford.tools.classify.classify`, although that function
     does a little more work in order to produce full characterizations.
     """
-    g_pres = grades_present(mv, 0.00000001)
+    g_pres = mv.grades(eps=0.00000001)
     if len(g_pres) != 1:  # Definitely not a blade
         return -1
     grade, = g_pres


### PR DESCRIPTION
We already expose this as a method, there's no need to provide two ways to do the same thing.
Note that the method previously did not allow the epsilon to be tweaked.
`eps` was chosen instead of `threshold` as the name to match other existing functions.