### PR TITLE
Remove implied __ne__ methods

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -433,14 +433,6 @@ class Layout(object):
         else:
             return NotImplemented
 
-    def __ne__(self, other):
-        if other is self:
-            return False
-        elif isinstance(other, Layout):
-            return not np.array_equal(self.sig, other.sig)
-        else:
-            return NotImplemented
-
     def parse_multivector(self, mv_string: str) -> 'cf.MultiVector':
         """ Parses a multivector string into a MultiVector object """
         # Get the names of the canonical blades

--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -558,12 +558,6 @@ class MultiVector(object):
         else:
             return False
 
-    def __ne__(self, other) -> bool:
-        ret = self.__eq__(other)
-        if ret is NotImplemented:
-            return ret
-        return not ret
-
     def clean(self, eps=None) -> 'MultiVector':
         """Sets coefficients whose absolute value is < eps to exactly 0.
 


### PR DESCRIPTION
In Python 3, `__ne__(a, b)` is defined by default as `not (a == b)`.
There is no need for us to manually implement the same thing.