### PR TITLE
Encapsulate ordering and naming conventions in separate classes

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -28,6 +28,17 @@ Whether you construct your algebras from scratch, or use the predefined ones, yo
     Layout
     ConformalLayout
 
+Advanced algebra configuration
+------------------------------
+It is unlikely you will need these features, but they remain as a better
+spelling for features which have always been in ``clifford``.
+
+.. autosummary::
+    :toctree: generated/
+
+    BasisBladeOrder
+    BasisVectorIds
+
 Global configuration functions
 ==============================
 These functions are used to change the global behavior of ``clifford``.
@@ -304,6 +315,7 @@ def val_get_right_gmt_matrix(mt: sparse.COO, x):
 from ._layout import Layout  # noqa: E402
 from ._multivector import MultiVector  # noqa: E402
 from ._conformal_layout import ConformalLayout  # noqa: E402
+from ._layout_helpers import BasisVectorIds, BasisBladeOrder  # noqa: F401
 from ._mvarray import MVArray, array  # noqa: F401
 from ._frame import Frame  # noqa: F401
 from ._blademap import BladeMap  # noqa: F401

--- a/clifford/_conformal_layout.py
+++ b/clifford/_conformal_layout.py
@@ -51,7 +51,10 @@ class ConformalLayout(Layout):
     def _from_base_layout(cls, layout, added_sig=[1, -1], **kwargs) -> 'ConformalLayout':
         """ helper to implement :func:`clifford.conformalize` """
         sig_c = list(layout.sig) + added_sig
-        return cls._from_sig(sig=sig_c, firstIdx=layout.firstIdx, layout=layout, **kwargs)
+        return cls(
+            sig_c,
+            ids=layout._basis_vector_ids.augmented_with(len(added_sig)),
+            layout=layout, **kwargs)
 
     # some convenience functions
     def up(self, x: MultiVector) -> MultiVector:

--- a/clifford/_layout_helpers.py
+++ b/clifford/_layout_helpers.py
@@ -1,0 +1,256 @@
+"""
+This module provides helpers that describe some aspect of a layout.
+
+The two public classes are:
+
+* BasisBladeOrder
+* BasisVectorIds
+
+"""
+
+from typing import TypeVar, Generic, Sequence, Tuple, List
+import numpy as np
+import functools
+import operator
+
+from . import _numba_utils
+
+
+@_numba_utils.njit
+def count_set_bits(bitmap):
+    """
+    Counts the number of bits set to 1 in bitmap
+    """
+    bmp = bitmap
+    count = 0
+    n = 1
+    while bmp > 0:
+        if bmp & 1:
+            count += 1
+        bmp = bmp >> 1
+        n = n + 1
+    return count
+
+
+@_numba_utils.njit
+def canonical_reordering_sign_euclidean(bitmap_a, bitmap_b):
+    """
+    Computes the sign for the product of bitmap_a and bitmap_b
+    assuming a euclidean metric
+    """
+    a = bitmap_a >> 1
+    sum_value = 0
+    while a != 0:
+        sum_value = sum_value + count_set_bits(a & bitmap_b)
+        a = a >> 1
+    if (sum_value & 1) == 0:
+        return 1
+    else:
+        return -1
+
+
+def _is_unique(x) -> bool:
+    return len(x) == len(set(x))
+
+
+class BasisBladeOrder:
+    """ Represents the storage order in memory of basis blade coefficients. """
+    def __init__(self, bitmaps):
+        if not _is_unique(bitmaps):
+            raise ValueError("blade bitmaps are not unique")
+        self.index_to_bitmap = np.array(bitmaps, dtype=int)
+        self.grades = np.zeros(len(self.index_to_bitmap))
+        for i, bitmap in enumerate(self.index_to_bitmap):
+            self.grades[i] = count_set_bits(bitmap)
+        # chosen so that no product of basis blades lies outside this mapping
+        largest = np.bitwise_or.reduce(self.index_to_bitmap) + 1
+        self.bitmap_to_index = np.full(largest, -1, dtype=int)
+        self.bitmap_to_index[self.index_to_bitmap] = np.arange(len(self.index_to_bitmap), dtype=int)
+
+    def __repr__(self) -> str:
+        bitmap_strs = ['{:b}'.format(bitmap) for bitmap in self.index_to_bitmap]
+        max_bits = max((len(s) for s in bitmap_strs), default=0)
+        bitmap_strs = ['0b' + s.rjust(max_bits, '0') for s in bitmap_strs]
+        return "{}([{}])".format(type(self).__name__, ', '.join(bitmap_strs))
+
+    def __hash__(self) -> int:
+        return hash(self.index_to_bitmap.tobytes())
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        if not isinstance(other, BasisBladeOrder):
+            return NotImplemented
+        return np.array_equal(self.index_to_bitmap, other.index_to_bitmap)
+
+    @classmethod
+    def shortlex(cls, n_vectors: int) -> 'BasisBladeOrder':
+        """
+        Get an optimized shortlex ordering.
+
+        This sorts basis blades first by grade, and then lexicographically.
+        """
+        return _ShortLexBasisBladeOrder(n_vectors)
+
+
+class _ShortLexBasisBladeOrder(BasisBladeOrder):  # lgtm [py/missing-call-to-init]
+    def __init__(self, n_vectors: int):
+        # deliberately skip the base class init, we can do a little better
+        self._n = n_vectors
+
+        # could attempt to optimize this by avoiding going via python integers
+        # and copying the raw logic from
+        # python/cpython.git:Modules/itertoolsmodule.c@combinations_next.
+        from clifford import _powerset
+        self.index_to_bitmap = np.empty(2**n_vectors, dtype=int)
+        self.grades = np.empty(2**n_vectors, dtype=int)
+        self.bitmap_to_index = np.empty(2**n_vectors, dtype=int)
+
+        for i, t in enumerate(_powerset([1 << i for i in range(n_vectors)])):
+            bitmap = functools.reduce(operator.or_, t, 0)
+            self.index_to_bitmap[i] = bitmap
+            self.grades[i] = len(t)
+            self.bitmap_to_index[bitmap] = i
+            del t  # enables an optimization inside itertools.combinations
+
+    def __repr__(self):
+        return 'BasisBladeOrder.shortlex({})'.format(self._n)
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        if not isinstance(other, _ShortLexBasisBladeOrder):
+            return NotImplemented
+        return self._n == other._n
+
+    def __reduce__(self):
+        return __class__, (self._n,)
+
+
+IdT = TypeVar('IdT')
+
+
+class BasisVectorIds(Generic[IdT]):
+    """
+    Stores ids for the ordered set of basis vectors, typically integers.
+
+    Provides helpers to convert between bitmaps indicating which vectors are
+    present in a blade, and tuples of the original ids.
+
+    For example::
+
+    >>> ids = BasisVectorIds([11, 22, 33])
+    >>> ids.bitmap_as_tuple(0b110)
+    (22, 33)
+    >>> ids.tuple_as_sign_and_bitmap((33, 22))
+    (-1, 0b110)
+    """
+    def __init__(self, blade_ids: Sequence[IdT]):
+        if not _is_unique(blade_ids):
+            raise ValueError("blade ids are not unique")
+        self.values = blade_ids
+
+    def bitmap_as_tuple(self, bitmap: int) -> Tuple[IdT]:
+        """ Convert a bitmap representation into a tuple of ids. """
+        bmp = bitmap
+        blade = []
+        n = 0
+        while bmp > 0:
+            if bmp & 1:
+                blade.append(self.values[n])
+            bmp = bmp >> 1
+            n = n + 1
+        return tuple(blade)
+
+    def id_as_bitmap(self, id: IdT) -> int:
+        """ Convert the id of a single vector into a bitmap representation. """
+        try:
+            return (1 << self.values.index(id))
+        except ValueError:
+            raise ValueError("Unknown basis {}".format(id)) from None
+
+    def tuple_as_sign_and_bitmap(self, blade: Tuple[IdT]) -> Tuple[int, int]:
+        """ Convert a blade from a tuple of ids into a bitmap representation. """
+        bitmap_out = 0
+        s = 1
+        for b in blade:
+            bitmap_b = self.id_as_bitmap(b)
+            if bitmap_b & bitmap_out:
+                raise ValueError("blade contains repeated basis vector {}".format(b))
+            # as we don't allow repeated indices, the euclidean version is fine
+            s *= canonical_reordering_sign_euclidean(bitmap_out, bitmap_b)
+            bitmap_out ^= bitmap_b
+        return s, bitmap_out
+
+    def order_from_tuples(self, blades: Sequence[Tuple[IdT]]) -> BasisBladeOrder:
+        """ Produce an ordering from a set of tuples.
+
+        This is the inverse of :meth:`order_as_tuples`.
+
+        >>> ids = BasisVectorIds(['x', 'y'])
+        >>> ids.order_from_tuples([(), ('y'), ('x', 'y'), ('x')])
+        BasisBladeOrder([0b00, 0b10, 0b11, 0b01])
+        """
+        bitmaps = []
+        for blade in blades:
+            s, bitmap = self.tuple_as_sign_and_bitmap(blade)
+            if s != 1:
+                raise NotImplementedError(
+                    "The blade {} is not canonical, and sign flips in storage "
+                    "are not supported. Did you mean {}?"
+                    .format(blade, self.bitmap_as_tuple(bitmap))
+                )
+            bitmaps.append(bitmap)
+        return BasisBladeOrder(bitmaps)
+
+    def order_as_tuples(self, ordering: BasisBladeOrder) -> List[Tuple[IdT]]:
+        """ Represent an ordering with these ids.
+
+        This is the inverse of :meth:`order_from_tuples`.
+
+        >>> ids = BasisVectorIds(['x', 'y'])
+        >>> ids.order_as_tuples(BasisBladeOrder([0b00, 0b10, 0b11, 0b01]))
+        [(), ('y'), ('x', 'y'), ('x')])
+        """
+        return [self.bitmap_as_tuple(b) for b in ordering.index_to_bitmap]
+
+    @classmethod
+    def ordered_integers(cls, n: int, *, first_index: int = 1) -> 'BasisVectorIds[int]':
+        """ Create a set of `n` sequential integers as ids, starting from `first_index`. """
+        # special type is an optimization
+        return _OrderedIntegerBasisVectorIds(n, first_index=first_index)
+
+    def augmented_with(self, n: int) -> 'BasisVectorIds':
+        """ Return a new copy with `n` new ids at the end. """
+        value = list(self.values)
+        next_id = max(value) + 1
+        value += list(range(next_id, next_id + n))
+        return BasisVectorIds(value)
+
+    def __repr__(self) -> str:
+        return '{}({!r})'.format(type(self).__name__, self.values)
+
+    def __reduce__(self):
+        return __class__, (self.values,)
+
+
+class _OrderedIntegerBasisVectorIds(BasisVectorIds[int]):
+    def __init__(self, n, first_index=1):
+        self._n = n
+        self._first_index = first_index
+        super().__init__(range(first_index, first_index + n))
+
+    def augmented_with(self, n):
+        return _OrderedIntegerBasisVectorIds(self._n + n, first_index=self._first_index)
+
+    def __repr__(self):
+        if self._first_index == 1:
+            return 'BasisVectorIds.ordered_integers({})'.format(self._n)
+        else:
+            return 'BasisVectorIds.ordered_integers({}, first_index={})'.format(self._n, self._first_index)
+
+    def __reduce__(self):
+        if self._first_index == 1:
+            return __class__, (self._n,)
+        else:
+            return __class__, (self._n, self._first_index)

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -627,9 +627,9 @@ class TestPrettyRepr:
     def test_layout(self, g3):
         expected = textwrap.dedent("""\
         Layout([1, 1, 1],
-               [(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)],
-               names=['', 'e1', 'e2', 'e3', 'e12', 'e13', 'e23', 'e123'],
-               firstIdx=1)""")
+               ids=BasisVectorIds.ordered_integers(3),
+               order=BasisBladeOrder.shortlex(3),
+               names=['', 'e1', 'e2', 'e3', 'e12', 'e13', 'e23', 'e123'])""")
         assert pretty.pretty(g3) == expected
 
     def test_multivector(self, g2):
@@ -638,9 +638,9 @@ class TestPrettyRepr:
 
         expected = textwrap.dedent("""\
         MultiVector(Layout([1, 1],
-                           [(), (1,), (2,), (1, 2)],
-                           names=['', 'e1', 'e2', 'e12'],
-                           firstIdx=1),
+                           ids=BasisVectorIds.ordered_integers(2),
+                           order=BasisBladeOrder.shortlex(2),
+                           names=['', 'e1', 'e2', 'e12']),
                     [0, 1, 2, 3],
                     dtype=int32)""")
 

--- a/clifford/test/test_layout.py
+++ b/clifford/test/test_layout.py
@@ -1,0 +1,61 @@
+import pytest
+
+from clifford import Layout, BasisBladeOrder, BasisVectorIds
+
+
+class TestLayout:
+    def test_defaults(self):
+        l = Layout([1, 1], names='v')
+        assert l.basis_names == ['v1', 'v2']
+
+    def test_deprecated_ctor(self):
+        with pytest.warns(DeprecationWarning, match=r'constructor.*instead'):
+            Layout(sig=[1, 1], bladeTupList=[(), (1,), (2,), (1, 2)], firstIdx=1, names="test")
+
+        # should work for positional arguments too
+        with pytest.warns(DeprecationWarning, match=r'constructor.*instead'):
+            Layout([1, 1], [(), (1,), (2,), (1, 2)])
+
+    def test_bad_ctor(self):
+        with pytest.raises(TypeError, match='__init__'):
+            Layout(sigtypo=[1, 1])
+
+        with pytest.raises(ValueError, match='length'):
+            Layout(sig=[1, 1], ids=BasisVectorIds(['not enough']))
+
+    def test_deprecated_firstIdx(self):
+        from clifford.g3 import layout
+        with pytest.warns(DeprecationWarning):
+            layout.firstIdx
+
+    def test_custom_blade_ids(self):
+        l = Layout(
+            [1, 1],
+            ids=BasisVectorIds(['y', 'x']),
+            order=BasisBladeOrder([0b00, 0b10, 0b01, 0b11])
+        )
+
+        blades = l.blades
+
+        # should match constructor order
+        assert l.basis_names == ['ey', 'ex']
+        assert l.basis_vectors_lst == [blades['ey'], blades['ex']]
+
+        # should match storage order
+        assert l.blades_of_grade(1) == [blades['ex'], blades['ey']]
+
+        with pytest.raises(AttributeError):
+            l.firstIdx
+
+    def test_swapped(self):
+        # swapping the order and id arguments should give an error
+        with pytest.raises(TypeError, match='order must'):
+            Layout(
+                [1, 1],
+                order=BasisVectorIds(['y', 'x'])
+            )
+        with pytest.raises(TypeError, match='ids must'):
+            Layout(
+                [1, 1],
+                ids=BasisBladeOrder([0b00, 0b10, 0b01, 0b11])
+            )

--- a/clifford/test/test_layout_helpers.py
+++ b/clifford/test/test_layout_helpers.py
@@ -1,0 +1,140 @@
+import pickle
+
+from numpy.testing import assert_equal
+import pytest
+
+from clifford._layout_helpers import BasisBladeOrder, BasisVectorIds
+
+
+class TestBasisBladeOrder:
+
+    def test_basic(self):
+        order = BasisBladeOrder([0b01, 0b11, 0b10, 0b00])
+        assert_equal(order.index_to_bitmap, [0b01, 0b11, 0b10, 0b00])
+        assert_equal(order.bitmap_to_index, [3, 0, 2, 1])
+        assert_equal(order.grades, [1, 2, 1, 0])
+
+        with pytest.raises(ValueError):
+            BasisBladeOrder([0, 0])
+
+    def test_sparse(self):
+        # -1 is inserted into the reverse mapping for missing blades
+        order = BasisBladeOrder([0b01, 0b10])
+        assert_equal(order.index_to_bitmap, [0b01, 0b10])
+        assert_equal(order.bitmap_to_index, [-1, 0, 1, -1])
+        assert_equal(order.grades, [1, 1])
+
+    def test_eq(self):
+        a = BasisBladeOrder([0b01, 0b11, 0b10, 0b00])
+        b = BasisBladeOrder([0b01, 0b11, 0b10, 0b00])
+        c = BasisBladeOrder([0b00, 0b01, 0b11, 0b10])
+        assert a == a
+        assert a == b
+        assert a != c
+        assert a != 0  # comparing against other objects is safe
+
+    def test_hash(self):
+        a = BasisBladeOrder([0b01, 0b11, 0b10, 0b00])
+        d = {a: True, None: False}
+        assert d[a] is True
+
+    def test_pickle(self):
+        a = BasisBladeOrder([0b01, 0b11, 0b10, 0b00])
+        assert pickle.loads(pickle.dumps(a)) == a
+
+    def test_repr(self):
+        two = BasisBladeOrder([0b00, 0b01, 0b11, 0b10])
+        assert repr(two) == "BasisBladeOrder([0b00, 0b01, 0b11, 0b10])"
+        one = BasisBladeOrder([0b0, 0b1])
+        assert repr(one) == "BasisBladeOrder([0b0, 0b1])"
+        zero = BasisBladeOrder([])
+        assert repr(zero) == "BasisBladeOrder([])"
+
+    def test_shortlex(self):
+        a = BasisBladeOrder([
+            0b000,
+            0b001, 0b010, 0b100,
+            0b011, 0b101, 0b110,
+            0b111
+        ])
+
+        b = BasisBladeOrder.shortlex(3)
+        assert_equal(a.index_to_bitmap, b.index_to_bitmap)
+        assert_equal(a.bitmap_to_index, b.bitmap_to_index)
+        assert_equal(a.grades, b.grades)
+
+        assert b == b
+        assert a == b
+        assert b == a
+
+        assert repr(b) == "BasisBladeOrder.shortlex(3)"
+
+        # shortlex is supposed to be smaller to save
+        assert len(pickle.dumps(b)) < len(pickle.dumps(a))
+
+        assert pickle.loads(pickle.dumps(b)) == b
+
+
+class TestBasisVectorIds:
+
+    def test_basic(self):
+        # no requirement that they be integers
+        a, b, c = (object() for i in range(3))
+        ids = BasisVectorIds([a, b, c])
+
+        assert ids.id_as_bitmap(a) == 0b001
+        assert ids.id_as_bitmap(c) == 0b100
+        with pytest.raises(ValueError):
+            ids.id_as_bitmap(object())
+
+        assert ids.bitmap_as_tuple(0b101) == (a, c)
+        assert ids.bitmap_as_tuple(0b011) == (a, b)
+        assert ids.bitmap_as_tuple(0b000) == ()
+
+        assert ids.tuple_as_sign_and_bitmap((a, c)) == (1, 0b101)
+        assert ids.tuple_as_sign_and_bitmap((c, a)) == (-1, 0b101)
+        assert ids.tuple_as_sign_and_bitmap(()) == (1, 0b000)
+        with pytest.raises(ValueError):
+            ids.tuple_as_sign_and_bitmap((a, a))
+
+        with pytest.raises(ValueError):
+            BasisVectorIds([a, a])
+
+    def test_repr(self):
+        ids = BasisVectorIds([1, 2, 3])
+        assert repr(ids) == "BasisVectorIds([1, 2, 3])"
+
+    def test_ordered(self):
+        ids = BasisVectorIds.ordered_integers(3)
+        assert repr(ids) == "BasisVectorIds.ordered_integers(3)"
+        assert list(ids.values) == [1, 2, 3]
+
+        ids = BasisVectorIds.ordered_integers(4, first_index=0)
+        assert repr(ids) == "BasisVectorIds.ordered_integers(4, first_index=0)"
+        assert list(ids.values) == [0, 1, 2, 3]
+
+    def test_pickle(self):
+        ids = BasisVectorIds([1, 2, 3])
+        assert pickle.loads(pickle.dumps(ids)).values == ids.values
+
+        ids = BasisVectorIds.ordered_integers(3)
+        assert pickle.loads(pickle.dumps(ids)).values == ids.values
+
+        ids = BasisVectorIds.ordered_integers(3, first_index=0)
+        assert pickle.loads(pickle.dumps(ids)).values == ids.values
+
+    def test_augment(self):
+        ids = BasisVectorIds([3, 2, 1])
+        assert ids.augmented_with(3).values == [3, 2, 1, 4, 5, 6]
+
+        ids = BasisVectorIds.ordered_integers(3)
+        assert ids.augmented_with(3).values == range(1, 7)
+
+    def test_order_from_tuples(self):
+        ids = BasisVectorIds([1, 2])
+        order = ids.order_from_tuples([(1, 2), (2,), (1,)])
+        assert order == BasisBladeOrder([0b11, 0b10, 0b01])
+
+        with pytest.raises(NotImplementedError):
+            # sign flip not allowed
+            ids.order_from_tuples([(2, 1)])

--- a/docs/predefined-algebras.rst
+++ b/docs/predefined-algebras.rst
@@ -53,9 +53,9 @@ Additionally, they define the following attributes, which contain the return val
         @doctest
         In [138]: g2.layout
         Out[138]: Layout([1, 1],
-               [(), (1,), (2,), (1, 2)],
-               names=['', 'e1', 'e2', 'e12'],
-               firstIdx=1)
+               ids=BasisVectorIds.ordered_integers(2),
+               order=BasisBladeOrder.shortlex(2),
+               names=['', 'e1', 'e2', 'e12'])
 
 .. data:: blades
 


### PR DESCRIPTION
The end goal here is to be able to more clearly separate which bits of `Layout` are specific to the algebra, and which are specific to the choice of blade names and numbers.

This makes the observation that our blade tuples, eg `(1, 2, 3)` &rarr; `e123` need not be integers at all. We already provide some flexibility via `firstIdx`, but the existence of this field resulted in some weird code that was cleaned up in #277. With this change, it's possible (but perhaps not adviseable) to have `('x', 'y', 'z')` &rarr; `exyz`:
```python
In [1]: from clifford import Layout

In [2]: from clifford._layout import BasisBladeOrder, BasisVectorIds

In [3]: l = Layout([1, 1, 1], ids=BasisVectorIds(['x', 'y', 'z']), order=BasisBladeOrder.shortlex(3))

In [4]: locals().update(l.blades)

In [5]: p = ex ^ ey; p
Out[5]: (1^exy)

In [6]: p['x', 'y']
Out[6]: 1

In [7]: l
Out[7]:
Layout([1, 1, 1],
       ids=BasisVectorIds(['x', 'y', 'z']),
       order=BasisBladeOrder.shortlex(3),
       names=['', 'ex', 'ey', 'ez', 'exy', 'exz', 'eyz', 'exyz'])
```

Perhaps more usefully, it's now legal to write just
```python
In [1]: from clifford import Layout

In [2]: Layout([1, 1, 1])
Out[2]:
Layout([1, 1, 1],
       ids=BasisVectorIds(['x', 'y', 'z']),
       order=BasisBladeOrder.shortlex(3),
       names=['', 'e1', 'e2', 'e3', 'e12', 'e13', 'e23', 'e123'])
```

This partially addresses #54.

The size of this patch is inflated a lot by docs and tests - the actual change is perhaps a net +300 line delta.