### PR TITLE
Fix bug in travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,11 @@ x-clifford-templates:
           PYTHON_VERSION="$TRAVIS_PYTHON_VERSION" CONDA_INSTALLER_OS="${TRAVIS_OS_NAME:-linux}" source travis_install_conda.sh \
             numpy \
             scipy \
-            numba \
             pip \
             IPython \
             h5py;
           conda install -c conda-forge sparse;
-          conda install -c numba numba>=0.45.1;
+          conda install -c numba "numba>=0.45.1";
         else
           pip install IPython;
         fi


### PR DESCRIPTION
The `>` was being interpreted as output redirection to the file `=0.45.1`, which was not at all reasonable.

Fixes gh-274