### PR TITLE
Remove `Layout.dict_to_multivector`.

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -397,13 +397,6 @@ class Layout(object):
     def basis_names(self):
         return np.array(list(sorted(self.basis_vectors.keys())), dtype=bytes)
 
-    def dict_to_multivector(self, dict_in):
-        """ Takes a dictionary of coefficient values and converts it into a MultiVector object """
-        constructed_values = np.zeros(self.gaDims)
-        for k in list(dict_in.keys()):
-            constructed_values[int(k)] = dict_in[k]
-        return self._newMV(constructed_values)
-
     def __repr__(self):
         return "{}({!r}, {!r}, firstIdx={!r}, names={!r})".format(
             type(self).__name__,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,8 @@ Compatibility notes
  * ``clifford.grades_present`` is deprecated in favor of
    :meth:`MultiVector.grades`, the latter of which now takes an ``eps`` argument.
  * ``del mv[i]`` is no longer legal, the equivalent ``mv[i] = 0`` should be used instead.
+ * ``Layout.dict_to_multivector`` has been removed. It was accidentally broken
+   in 1.0.5, so there is little point deprecating it.
 
 
 Changes in 1.2.x


### PR DESCRIPTION
This function does not work, as `self._newMV` is an AttributeError.

While we could easily fix this, this function has been broken since 2c6774fcfd2135bcea341bd7c5ccb7f6e638b917, and doesn't have a particularly convincing use-case anyway. It was added in 58e0f09d203d18b7865d46e2310c41bd8a0ddcf9

None of our tests or examples use this function, but it is used here: https://github.com/hugohadfield/GAonline/blob/747383ff42140ee3e1bbdd1c4ff904bfda72ba3b/main.py#L44