### PR TITLE
General cleanup around clifford.bases

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -56,7 +56,6 @@ Miscellaneous functions
     :toctree: generated/
 
     grade_obj
-    bases
     randomMV
 
 """
@@ -65,7 +64,7 @@ Miscellaneous functions
 import os
 import itertools
 import warnings
-from typing import List, Tuple, Set, Container, Dict, Optional
+from typing import List, Tuple, Set
 
 # Major library imports.
 import numpy as np
@@ -347,35 +346,12 @@ def Cl(p=0, q=0, r=0, sig=None, names=None, firstIdx=1, mvClass=MultiVector):
     return layout, layout.bases(mvClass=mvClass)
 
 
-def bases(layout, mvClass=MultiVector, grades: Optional[Container[int]] = None) -> Dict[str, MultiVector]:
-    """Returns a dictionary mapping basis element names to their MultiVector
-    instances, optionally for specific grades
-
-    if you are lazy,  you might do this to populate your namespace
-    with the variables of a given layout.
-
-    >>> locals().update(layout.blades())
-
-    .. versionchanged:: 1.1.0
-        This dictionary includes the scalar
-    """
-
-    dict = {}
-    for i in range(layout.gaDims):
-        grade = layout.gradeList[i]
-        if grades is not None and grade not in grades:
-            continue
-        v = np.zeros((layout.gaDims,), dtype=int)
-        v[i] = 1
-        dict[layout.names[i]] = mvClass(layout, v)
-    return dict
+def bases(layout, *args, **kwargs):
+    return layout.bases(*args, **kwargs)
 
 
 def basis_vectors(layout):
-    '''
-    dictionary of basis vectors
-    '''
-    return bases(layout=layout, grades=[1])
+    return layout.basis_vectors
 
 
 def randomMV(

--- a/clifford/_conformal_layout.py
+++ b/clifford/_conformal_layout.py
@@ -31,9 +31,7 @@ class ConformalLayout(Layout):
         super().__init__(*args, **kwargs)
         self._base_layout = layout
 
-        basis_vectors = self.basis_vectors
-        added_keys = sorted(basis_vectors.keys())[-2:]
-        ep, en = [basis_vectors[k] for k in added_keys]
+        ep, en = self.basis_vectors_lst[-2:]
 
         # setup  null basis, and minkowski subspace bivector
         eo = .5 ^ (en - ep)

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -389,10 +389,6 @@ class Layout(object):
             return lc_func(omt_func(rc_func(aval), rc_func(bval)))
         return vee
 
-    @property
-    def basis_names(self):
-        return np.array(list(sorted(self.basis_vectors.keys())), dtype=bytes)
-
     def __repr__(self):
         return "{}({!r}, {!r}, firstIdx={!r}, names={!r})".format(
             type(self).__name__,
@@ -716,6 +712,10 @@ class Layout(object):
     @property
     def basis_vectors(self):
         return cf.basis_vectors(self)
+
+    @property
+    def basis_names(self):
+        return np.array(list(sorted(self.basis_vectors.keys())), dtype=bytes)
 
     @property
     def basis_vectors_lst(self):

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -655,10 +655,11 @@ class Layout(object):
 
     @property
     def metric(self):
+        basis_vectors = self.basis_vectors_lst
         if self._metric is None:
-            self._metric = np.zeros((len(self.basis_vectors), len(self.basis_vectors)))
-            for i, v in enumerate(self.basis_vectors_lst):
-                for j, v2 in enumerate(self.basis_vectors_lst):
+            self._metric = np.zeros((len(basis_vectors), len(basis_vectors)))
+            for i, v in enumerate(basis_vectors):
+                for j, v2 in enumerate(basis_vectors):
                     self._metric[i, j] = (v | v2)[0]
             return self._metric.copy()
         else:

--- a/clifford/io.py
+++ b/clifford/io.py
@@ -111,7 +111,11 @@ def write_ga_file(file_name, mv_array, metric, basis_names, compression=True,
         dset_metric = f.create_dataset("metric", data=metric)
 
         # Now the basis names
-        dset_basis_names = f.create_dataset("basis_names", data=basis_names)
+        try:
+            dt = h5py.string_dtype()  # new in 2.10
+        except AttributeError:
+            dt = h5py.special_dtype(vlen=str)
+        dset_basis_names = f.create_dataset("basis_names", data=np.asarray(basis_names, dtype=dt))
 
 
 def read_ga_file(file_name):

--- a/clifford/test/test_io.py
+++ b/clifford/test/test_io.py
@@ -22,7 +22,7 @@ class TestHDF5BasicIO:
     def test_write_and_read(self, tmp_path):
         file_name = str(tmp_path / "test.ga")
 
-        basis_names = np.array(list(sorted(layout.basis_vectors.keys())), dtype=bytes)
+        basis_names = np.array(layout.basis_names, dtype=bytes)
 
         mv_array = ConformalMVArray([random_point_pair() for i in range(1000)]).value
         write_ga_file(file_name, mv_array, layout.metric, basis_names, compression=True,
@@ -50,7 +50,7 @@ class TestJSONBasicIO:
     def test_write_and_read(self, tmp_path):
         file_name = str(tmp_path / "test.ga.json")
 
-        basis_names = np.array(list(sorted(layout.basis_vectors.keys())))
+        basis_names = np.array(layout.basis_names, dtype=bytes)
 
         mv_array = ConformalMVArray([random_point_pair() for i in range(1000)]).value
         write_json_file(file_name, mv_array, layout.metric, basis_names, compression=True,

--- a/clifford/test/test_io.py
+++ b/clifford/test/test_io.py
@@ -22,7 +22,7 @@ class TestHDF5BasicIO:
     def test_write_and_read(self, tmp_path):
         file_name = str(tmp_path / "test.ga")
 
-        basis_names = np.array(layout.basis_names, dtype=bytes)
+        basis_names = np.array(layout.basis_names, dtype=str)
 
         mv_array = ConformalMVArray([random_point_pair() for i in range(1000)]).value
         write_ga_file(file_name, mv_array, layout.metric, basis_names, compression=True,
@@ -50,7 +50,7 @@ class TestJSONBasicIO:
     def test_write_and_read(self, tmp_path):
         file_name = str(tmp_path / "test.ga.json")
 
-        basis_names = np.array(layout.basis_names, dtype=bytes)
+        basis_names = np.array(layout.basis_names, dtype=str)
 
         mv_array = ConformalMVArray([random_point_pair() for i in range(1000)]).value
         write_json_file(file_name, mv_array, layout.metric, basis_names, compression=True,

--- a/clifford/tools/__init__.py
+++ b/clifford/tools/__init__.py
@@ -148,9 +148,7 @@ def mat2Frame(A, layout=None, is_complex=None):
     if layout is None:
         layout, blades = Cl(M)
 
-    e_ = layout.basis_vectors
-
-    e_ = [e_['e%i' % k] for k in range(layout.firstIdx, layout.firstIdx + M)]
+    e_ = layout.basis_vectors_lst[:M]
 
     a = [0 ^ e_[0]] * N
 
@@ -259,7 +257,7 @@ def orthoFrames2Versor(B, A=None, delta=1e-3, eps=None, det=None,
 
     A : list of vectors, or clifford.Frame
         the set of  vectors before the transform. If `None` we assume A is
-        the basis given B.layout.basis_vectors
+        the basis given B.layout.basis_vectors_lst
 
     delta : float
         Tolerance for reflection/rotation determination. If the normalized
@@ -300,8 +298,7 @@ def orthoFrames2Versor(B, A=None, delta=1e-3, eps=None, det=None,
     # Checking and Setup
     if A is None:
         # assume we have orthonormal initial frame
-        bv = B[0].layout.basis_vectors
-        A = [bv[k] for k in sorted(bv.keys())]
+        A = B[0].layout.basis_vectors_lst
 
     # make copy of original frames, so we can rotate A
     A = A[:]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,10 @@ Compatibility notes
  * ``del mv[i]`` is no longer legal, the equivalent ``mv[i] = 0`` should be used instead.
  * ``Layout.dict_to_multivector`` has been removed. It was accidentally broken
    in 1.0.5, so there is little point deprecating it.
+ * :meth:`Layout.basis_names` now returns a ``list`` of ``str``, rather than a
+   numpy array of ``bytes``. The result now matches the construction order, rather
+   than being sorted alphabetically. The order of :meth:`Layout.metric` has
+   been adjusted for consistency.
 
 
 Changes in 1.2.x


### PR DESCRIPTION
This tries to unify the implementations of

* `clifford.bases`
* `clifford.basis_vectors`
* `clifford.Layout.bases`
* `clifford.Layout.basis_vectors`
* `clifford.Layout.basis_names`
* `clifford.Layout.basis_vectors_lst`
* `clifford.Layout.blades_of_grade`
* `clifford.Layout.blades_lst`

It also fixes some weird behavior where basis names were sorted alphabetically, rather than in the order they were passed.