### PR TITLE
Reduce travis CI time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,25 @@ x-clifford-templates:
       - pip install codecov
     script:
       - |
+        PYTEST_ARGS=();
+        if [[ "${MODE}" == "bench" ]]; then
+          PYTEST_ARGS+=(--benchmark-only);
+        else
+          PYTEST_ARGS+=(--benchmark-skip);
+        fi;
+        if [[ "${MODE}" == "very_slow" ]]; then
+          PYTEST_ARGS+=(-m "veryslow");
+        else
+          PYTEST_ARGS+=(-m "not veryslow");
+        fi;
+
         pytest clifford/test \
-          ${PYTEST_ARGS} \
+          "${PYTEST_ARGS[@]}" \
           --doctest-modules \
           --junitxml=junit/test-results.xml \
           --durations=25 \
           --cov=clifford \
-          --cov-branch
+          --cov-branch;
     after_success:
       - codecov
 
@@ -64,45 +76,7 @@ matrix:
       stage: Lint
       <<: *lint_job
 
-    - os: linux
-      python: '3.5'
-      env:
-        - CONDA=false
-        - PYTEST_ARGS=--benchmark-skip
-      stage: Test
-      <<: *test_job
-
-    - os: linux
-      python: '3.8'
-      env:
-        - CONDA=false
-        - PYTEST_ARGS=--benchmark-skip
-      stage: Test
-      <<: *test_job
-
-    - os: linux
-      python: '3.8'
-      env:
-        - CONDA=false
-        - PYTEST_ARGS=--benchmark-only
-      stage: Test
-      <<: *test_job
-
-    - os: linux
-      python: '3.5'
-      env:
-        - CONDA=true
-        - PYTEST_ARGS=--benchmark-skip
-      stage: Test
-      <<: *test_job
-
-    - os: linux
-      python: '3.8'
-      env:
-        - CONDA=true
-        - PYTEST_ARGS=--benchmark-skip
-      stage: Test
-      <<: *test_job
+    # fastest job first
     - os: linux
       python: '3.8'
       env:
@@ -110,6 +84,49 @@ matrix:
       stage: Test
       <<: *test_job
 
+    # really slow job second, so it runs in parallel with the others
+    - os: linux
+      python: '3.8'
+      env:
+        - MODE=very_slow
+      stage: Test
+      <<: *test_job
+
+    # non-conda jobs
+    - os: linux
+      python: '3.8'
+      stage: Test
+      <<: *test_job
+
+    - os: linux
+      python: '3.5'
+      stage: Test
+      <<: *test_job
+
+    # conda jobs
+    - os: linux
+      python: '3.8'
+      env:
+        - CONDA=true
+      stage: Test
+      <<: *test_job
+
+    - os: linux
+      python: '3.5'
+      env:
+        - CONDA=true
+      stage: Test
+      <<: *test_job
+
+    # benchmark
+    - os: linux
+      python: '3.8'
+      env:
+        - MODE=bench
+      stage: Test
+      <<: *test_job
+
+    # deployment
     - os: linux
       python: '3.8'
       stage: Deploy

--- a/clifford/test/test_algebra_initialisation.py
+++ b/clifford/test/test_algebra_initialisation.py
@@ -22,6 +22,7 @@ class TestInitialisation:
         benchmark(Cl, n)
 
     @too_slow_without_jit
+    @pytest.mark.veryslow
     @pytest.mark.parametrize(
         'algebra',
         [Cl(i) for i in [4]] + [conformalize(Cl(3)[0])],

--- a/clifford/test/test_g3c_tools.py
+++ b/clifford/test/test_g3c_tools.py
@@ -178,7 +178,7 @@ class TestGeneralLogarithm:
         random_point_pair, random_line, random_circle, random_plane
     ])
     def test_general_logarithm_conformal(self, obj_gen):
-        for i in range(10000):
+        for i in range(1000):
             X = obj_gen()
             Y = obj_gen()
             R = rotor_between_objects(X, Y)

--- a/clifford/test/test_g3c_tools.py
+++ b/clifford/test/test_g3c_tools.py
@@ -890,6 +890,7 @@ class TestObjectClustering:
 @too_slow_without_jit
 class TestModelMatching:
 
+    @pytest.mark.veryslow
     def test_fingerprint_match(self):
 
         object_generator = random_line

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,3 +63,7 @@ per-file-ignores =
 
     # generated, so we don't really care
     clifford/tools/g3c/cuda_products.py:F401,E302,E231,W391
+
+[tool:pytest]
+markers =
+    veryslow: mark a test as unreasonably slow (> 30s on travis)


### PR DESCRIPTION
Partially addresses #278.

This runs the really slow tests just once, rather than 4 times, `(3.5, 3.8) x (conda, not conda)`.