### PR TITLE
Improve performance of arithmetic on MultiVector pairs

### DIFF
--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -61,7 +61,13 @@ class MultiVector(object):
 
         _checkOther(other, coerce=True) --> newOther, isMultiVector
         """
-        if isinstance(other, numbers.Number):
+        if isinstance(other, MultiVector):
+            if other.layout != self.layout:
+                raise ValueError(
+                    "cannot operate on MultiVectors with different Layouts")
+            else:
+                return other, True
+        elif isinstance(other, numbers.Number):
             if coerce:
                 # numeric scalar
                 newOther = self._newMV(dtype=np.result_type(other))
@@ -70,12 +76,6 @@ class MultiVector(object):
             else:
                 return other, False
 
-        elif isinstance(other, MultiVector):
-            if other.layout != self.layout:
-                raise ValueError(
-                    "cannot operate on MultiVectors with different Layouts")
-            else:
-                return other, True
         else:
             return other, False
 


### PR DESCRIPTION
The previous code was optimized for `MultiVector <op> something_else`, incurring an expensive `isinstance(other, numbers.Number)` check.

This changes it to check `isinstance(other, MultiVector)` first, which is the case that is going to be most frequent.

Extracted from #280, since it's a tiny patch