### PR TITLE
Move some tests that ended up within the wrong class

### DIFF
--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -429,6 +429,54 @@ class TestClifford:
             # no guarantees about sign, magnitude, or orthogonality
             assert equivalent_up_to_scale(roundtrip, blade)
 
+    def test_join(self, g5):
+        e1 = g5.blades['e1']
+        e2 = g5.blades['e2']
+        e3 = g5.blades['e3']
+        e4 = g5.blades['e4']
+        e5 = g5.blades['e5']
+
+        a = e5
+        b = e1 + e4
+        c = e1 + e3
+        d = e2 + e1
+        e = e4 + e2
+        # chosen specifically to satisfy...
+        assert len(((a^b^c)*(a^d^e)).grades()) > 2
+
+        assert equivalent_up_to_scale(g5.scalar.join(1), 1)
+        assert equivalent_up_to_scale((a).join(1), a)
+        assert equivalent_up_to_scale((a).join(a), a)
+
+        assert equivalent_up_to_scale((a).join(a), a)
+        assert equivalent_up_to_scale((a).join(b), a^b)
+        assert equivalent_up_to_scale((a^b).join(b^c), a^b^c)
+        assert equivalent_up_to_scale((a).join(b^c), a^b^c)
+        assert equivalent_up_to_scale((a^b).join(c), a^b^c)
+
+        # should be commutative up to scale
+        assert equivalent_up_to_scale((a).join(a^b), a^b)
+        assert equivalent_up_to_scale((a^b).join(a), a^b)
+
+        # need this test to avoid a fast-path
+        assert equivalent_up_to_scale((a^b^c).join(a^d^e), a^b^c^d^e)
+
+    def test_meet(self, g3):
+        e1 = g3.blades['e1']
+        e2 = g3.blades['e2']
+        e3 = g3.blades['e3']
+
+        assert equivalent_up_to_scale((g3.scalar).meet(g3.scalar), g3.scalar)
+        assert equivalent_up_to_scale((e1^e2).meet(e2^e3), e2)
+
+        a, b, c = (e1 + e2), (e1 + e3), (e2 + e3)
+        assert equivalent_up_to_scale((a^b).meet(b^c), b)
+        assert equivalent_up_to_scale((a^b^c).meet(b^c), b^c)
+
+        assert equivalent_up_to_scale((a).meet(b^c), 1)
+        assert equivalent_up_to_scale((b^c).meet(a), 1)
+        assert equivalent_up_to_scale((a).meet(a), a)
+
 
 class TestBasicConformal41:
     def test_metric(self, g4_1):
@@ -670,54 +718,6 @@ class TestPrettyRepr:
             assert pretty.pretty(p_f) == expected_f
         finally:
             clifford.pretty()
-
-    def test_join(self, g5):
-        e1 = g5.blades['e1']
-        e2 = g5.blades['e2']
-        e3 = g5.blades['e3']
-        e4 = g5.blades['e4']
-        e5 = g5.blades['e5']
-
-        a = e5
-        b = e1 + e4
-        c = e1 + e3
-        d = e2 + e1
-        e = e4 + e2
-        # chosen specifically to satisfy...
-        assert len(((a^b^c)*(a^d^e)).grades()) > 2
-
-        assert equivalent_up_to_scale(g5.scalar.join(1), 1)
-        assert equivalent_up_to_scale((a).join(1), a)
-        assert equivalent_up_to_scale((a).join(a), a)
-
-        assert equivalent_up_to_scale((a).join(a), a)
-        assert equivalent_up_to_scale((a).join(b), a^b)
-        assert equivalent_up_to_scale((a^b).join(b^c), a^b^c)
-        assert equivalent_up_to_scale((a).join(b^c), a^b^c)
-        assert equivalent_up_to_scale((a^b).join(c), a^b^c)
-
-        # should be commutative up to scale
-        assert equivalent_up_to_scale((a).join(a^b), a^b)
-        assert equivalent_up_to_scale((a^b).join(a), a^b)
-
-        # need this test to avoid a fast-path
-        assert equivalent_up_to_scale((a^b^c).join(a^d^e), a^b^c^d^e)
-
-    def test_meet(self, g3):
-        e1 = g3.blades['e1']
-        e2 = g3.blades['e2']
-        e3 = g3.blades['e3']
-
-        assert equivalent_up_to_scale((g3.scalar).meet(g3.scalar), g3.scalar)
-        assert equivalent_up_to_scale((e1^e2).meet(e2^e3), e2)
-
-        a, b, c = (e1 + e2), (e1 + e3), (e2 + e3)
-        assert equivalent_up_to_scale((a^b).meet(b^c), b)
-        assert equivalent_up_to_scale((a^b^c).meet(b^c), b^c)
-
-        assert equivalent_up_to_scale((a).meet(b^c), 1)
-        assert equivalent_up_to_scale((b^c).meet(a), 1)
-        assert equivalent_up_to_scale((a).meet(a), a)
 
 
 class TestFrame:


### PR DESCRIPTION
These tests are not pretty-print tests. Will merge when CI passes.