### PR TITLE
Do not allow numba to be the broken release-candidate which we are not compatible with.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ x-clifford-templates:
             IPython \
             h5py;
           conda install -c conda-forge sparse;
-          conda install -c numba "numba>=0.45.1";
+          conda install -c numba "numba>=0.45.1,!=0.49.0rc1";
         else
           pip install IPython;
         fi

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'numpy',
         'scipy',
-        'numba > 0.46',
+        'numba > 0.46, != 0.49.0rc1',
         'h5py',
         'sparse',
     ],


### PR DESCRIPTION
Hopefully CI will pass on the 3.8 conda run, which it previously did not