### PR TITLE
Ensure doctests are run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,12 @@ x-clifford-templates:
         else
           PYTEST_ARGS+=(-m "not veryslow");
         fi;
+        if [[ "${MODE}" == "doctests" ]]; then
+          PYTEST_ARGS+=(--doctest-modules --ignore clifford/test);
+        fi;
 
-        pytest clifford/test \
+        pytest \
           "${PYTEST_ARGS[@]}" \
-          --doctest-modules \
           --junitxml=junit/test-results.xml \
           --durations=25 \
           --cov=clifford \
@@ -76,7 +78,7 @@ matrix:
       stage: Lint
       <<: *lint_job
 
-    # fastest job first
+    # fastest jobs first
     - os: linux
       python: '3.8'
       env:
@@ -84,7 +86,14 @@ matrix:
       stage: Test
       <<: *test_job
 
-    # really slow job second, so it runs in parallel with the others
+    - os: linux
+      python: '3.8'
+      env:
+        - MODE=doctests
+      stage: Test
+      <<: *test_job
+
+    # really slow job next, so it runs in parallel with the others
     - os: linux
       python: '3.8'
       env:

--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -379,7 +379,7 @@ def randomMV(
 
     Examples
     --------
-    >>> randomMV(layout, min=-2.0, max=2.0, grades=None, uniform=None, n=2)
+    >>> randomMV(layout, min=-2.0, max=2.0, grades=None, uniform=None, n=2)  # doctest: +SKIP
 
     """
 

--- a/clifford/_blademap.py
+++ b/clifford/_blademap.py
@@ -13,11 +13,11 @@ class BladeMap(object):
     >>> P, P_blades = Cl(3, names='p')
     >>> locals().update(P_blades)
     >>> sta_split = BladeMap([(d01, p1),
-                              (d02, p2),
-                              (d03, p3),
-                              (d12, p12),
-                              (d23, p23),
-                              (d13, p13)])
+    ...                       (d02, p2),
+    ...                       (d03, p3),
+    ...                       (d12, p12),
+    ...                       (d23, p23),
+    ...                       (d13, p13)])
 
     '''
     def __init__(self, blades_map, map_scalars=True):

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -793,7 +793,7 @@ class Layout(object):
         if you are lazy,  you might do this to populate your namespace
         with the variables of a given layout.
 
-        >>> locals().update(layout.blades())
+        >>> locals().update(layout.blades())  # doctest: +SKIP
 
         .. versionchanged:: 1.1.0
             This dictionary includes the scalar

--- a/clifford/_layout_helpers.py
+++ b/clifford/_layout_helpers.py
@@ -148,8 +148,8 @@ class BasisVectorIds(Generic[IdT]):
         >>> ids = BasisVectorIds([11, 22, 33])
         >>> ids.bitmap_as_tuple(0b110)
         (22, 33)
-        >>> ids.tuple_as_sign_and_bitmap((33, 22))
-        (-1, 0b110)
+        >>> sign, bitmap = ids.tuple_as_sign_and_bitmap((33, 22))
+        >>> assert sign, bitmap == (-1, 0b110)
     """
     def __init__(self, blade_ids: Sequence[IdT]):
         if not _is_unique(blade_ids):
@@ -186,7 +186,7 @@ class BasisVectorIds(Generic[IdT]):
         This is the inverse of :meth:`order_as_tuples`.
 
         >>> ids = BasisVectorIds(['x', 'y'])
-        >>> ids.order_from_tuples([(), ('y'), ('x', 'y'), ('x')])
+        >>> ids.order_from_tuples([(), ('y',), ('x', 'y'), ('x',)])
         BasisBladeOrder([0b00, 0b10, 0b11, 0b01])
         """
         bitmaps = []
@@ -208,7 +208,7 @@ class BasisVectorIds(Generic[IdT]):
 
         >>> ids = BasisVectorIds(['x', 'y'])
         >>> ids.order_as_tuples(BasisBladeOrder([0b00, 0b10, 0b11, 0b01]))
-        [(), ('y'), ('x', 'y'), ('x')])
+        [(), ('y',), ('x', 'y'), ('x',)]
         """
         return [self.bitmap_as_tuple(b) for b in ordering.index_to_bitmap]
 

--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -425,8 +425,12 @@ class MultiVector(object):
 
         Examples
         --------
+        >>> from clifford.g2 import *
+        >>> M = 1 + 2*e1 + 3*e12
         >>> M(0)
+        1
         >>> M(0, 2)
+        1 + (3^e12)
         """
         if isinstance(other, MultiVector):
             return other.project(self)

--- a/clifford/_mvarray.py
+++ b/clifford/_mvarray.py
@@ -110,7 +110,8 @@ def array(obj):
     >>> import clifford as cf
     >>> from clifford import g3
     >>> import numpy as np
-    >>> np.random.rand(10)*cf.array(g3.e12)
+    >>> np.array([1, 2, 3])*cf.array(g3.e12)
+    MVArray([(1^e12), (2^e12), (3^e12)], dtype=object)
     '''
     if isinstance(obj, MultiVector):
         # they passed a single MV so make a list of it.

--- a/clifford/cga.py
+++ b/clifford/cga.py
@@ -11,12 +11,14 @@ Examples
 -----------
 >>> from clifford import Cl
 >>> from clifford.cga import CGA
->>> g3, blades  = Cl(3)
+>>> g3, blades = Cl(3)
+>>> locals().update(blades)
 >>> g3c = CGA(g3)
 >>> C = g3c.round(3)             # create random sphere
 >>> T = g3c.translation(e1+e2)   # create translation
 >>> C_ = T(C)                    # translate the sphere
 >>> C_.center                    # compute center of sphere
+-(1.0^e4) - (1.0^e5)
 
 The CGA
 ========
@@ -142,10 +144,12 @@ class Flat(CGAThing):
         Examples
         ----------
 
-        >>> cga.flat()               # from None
-        >>> cga.flat(2)              # from dim of space
-        >>> cga.flat(e1, e2)         # from points
-        >>> cga.flat(cga.flat().mv)  # from existing multivector
+        >>> cga = CGA(3)
+        >>> locals().update(cga.blades)
+        >>> F = cga.flat()               # from None
+        >>> F = cga.flat(2)              # from dim of space
+        >>> F = cga.flat(e1, e2)         # from points
+        >>> F = cga.flat(cga.flat().mv)  # from existing multivector
         '''
     # could inherent some generic CGAObject class
     def __init__(self, cga, *args) -> None:
@@ -206,10 +210,16 @@ class Round(CGAThing):
     Examples
     ----------
 
+    >>> cga = CGA(3)
+    >>> locals().update(cga.blades)
     >>> cga.round()               # from None
+    Sphere
     >>> cga.round(2)              # from dim of space
+    Sphere
     >>> cga.round(e1, e2, -e1)    # from points
+    Circle
     >>> cga.round(cga.flat().mv)  # from existing multivector
+    Sphere
     '''
     # could inherent some generic CGAObject class
     def __init__(self, cga, *args) -> None:
@@ -323,6 +333,8 @@ class Translation(CGAThing):
 
     Examples
     ----------
+    >>> cga = CGA(3)
+    >>> locals().update(cga.blades)
     >>> T = cga.translation()       # from None
     >>> T = cga.translation(e1+e2)  # from base vector
     >>> T = cga.translation(cga.up(e1+e2)) # from null vector
@@ -366,6 +378,7 @@ class Dilation(CGAThing):
 
     Examples
     ----------
+    >>> cga = CGA(3)
     >>> D = cga.dilation()          # from  none
     >>> D = cga.dilation(.4)        # from number
     '''
@@ -416,6 +429,8 @@ class Rotation(CGAThing):
 
     Examples
     ----------
+    >>> cga = CGA(3)
+    >>> locals().update(cga.blades)
     >>> R = cga.rotation()          # from None
     >>> R = cga.rotation(e12+e23)   # from bivector
     >>> R = cga.rotation(R.mv)   # from bivector
@@ -480,9 +495,12 @@ class Transversion(Translation):
 
     Examples
     ----------
+    >>> cga = CGA(3)
+    >>> locals().update(cga.blades)
     >>> K = cga.transversion()       # from None
     >>> K = cga.transversion(e1+e2)  # from base vector
     >>> K = cga.transversion(cga.up(e1+e2)) # from null vector
+    >>> T = cga.translation()
     >>> K = cga.transversion(T.mv)  # from existing translation rotor
     '''
     def __init__(self, cga, *args) -> None:

--- a/clifford/operator.py
+++ b/clifford/operator.py
@@ -10,8 +10,9 @@ It can be thought of as equivalent to the builtin :mod:`operator` module, but fo
 
     >>> import functools
     >>> import clifford.operator
-    >>> Ms = [M1, M2, M3] # list of multivectors
-    >>> assert functools.reduce(clifford.operator.op, Ms) == M1 ^ M2 ^ M3
+    >>> from clifford.g3 import *
+    >>> Ms = [e1, e1 + e2, e2 + e3]  # list of multivectors
+    >>> assert functools.reduce(clifford.operator.op, Ms) == Ms[0] ^ Ms[1] ^ Ms[2]
 
 .. autofunction:: gp
 

--- a/clifford/tools/classify.py
+++ b/clifford/tools/classify.py
@@ -27,9 +27,9 @@ interpretation::
 
     >>> from clifford.g3c import *
     >>> Round(location=e1, direction=e1^e2, radius=1)
-    Circle(location=(1^e1), direction=(1^e12), radius=1)
-    >>> Round(location=e1, direction=e1^e2^e3, radius=1)
-    Sphere(location=(1^e1), direction=(1^e123), radius=1)
+    Circle(direction=(1^e12), location=(1^e1), radius=1)
+    >>> Round(direction=e1^e2^e3, location=e1, radius=1)
+    Sphere(direction=(1^e123), location=(1^e1), radius=1)
 
 
 Aliased types
@@ -424,13 +424,13 @@ def classify(x) -> Blade:
         >>> from clifford.g3c import *
 
         >>> classify(e1)
-        DualFlat[1](location=0, direction=-(1.0^e23))
+        DualFlat[1](flat=Plane(direction=-(1.0^e23), location=0))
 
         >>> classify(einf)
         InfinitePoint(direction=1.0)
 
         >>> classify(up(e1))
-        Point(location=(1.0^e1), direction=1.0)
+        Point(direction=1.0, location=(1.0^e1))
 
         >>> classify(up(3*e1)^up(4*e2))
         PointPair(direction=-(3.0^e1) + (4.0^e2), location=(1.5^e1) + (2.0^e2), radius=2.5)
@@ -445,7 +445,7 @@ def classify(x) -> Blade:
         Tangent[2](direction=(1.0^e2), location=(1.0^e1))
 
         # how the inheritance works
-        >>> Point.mro()
+        >>> Point.mro()  # doctest: +SKIP
         [Point, Tangent[1], Round[1], Blade[1], Tangent, Round, Blade, object]
 
     The reverse of this operation is :attr:`Blade.mv`.

--- a/clifford/transformations.py
+++ b/clifford/transformations.py
@@ -229,14 +229,16 @@ class OutermorphismMatrix(LinearMatrix):
 
     Applying it to some multivectors::
 
-        # the transformation we specified
+        >>> # the transformation we specified
         >>> lt(e1), lt(e2), lt(e3)
         ((3^f3), (1^f1), (2^f2))
-        # the one deduced by outermorphism
-        >>> lt(e12), lt(e23), lt(e13)
+
+        >>> # the one deduced by outermorphism
+        >>> lt(e1^e2), lt(e2^e3), lt(e1^e3)
         (-(3^f13), (2^f12), -(6^f23))
-        # and by distributivity
-        >>> lt(1 + e123)
+
+        >>> # and by distributivity
+        >>> lt(1 + (e1^e2^e3))
         1 + (6^f123)
 
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,3 +70,5 @@ per-file-ignores =
 [tool:pytest]
 markers =
     veryslow: mark a test as unreasonably slow (> 30s on travis)
+
+norecursedirs = docs


### PR DESCRIPTION
Previously because pytest was pointed only to the test directory, it would not find the doctests in clifford itself.
The only reason this was done was because the `docs` directory contains files that pytest crashes on.
Ignoring this directory makes everything work.