### PR TITLE
Avoid crashes building llvmlite in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ x-clifford-templates:
         if [[ "${CONDA}" == "true" ]]; then
           python setup.py develop --no-deps;
         else
-          pip install .;
+          # this avoids an issue where Python 3.5 wheels are missing for llvmlite
+          pip install . --prefer-binary;
         fi
       # always install with pip, conda has too old a version
       - pip install pytest pytest-cov pytest-benchmark


### PR DESCRIPTION
The later versions of llvmlite do not have a Python 3.5 wheel on PyPI, so travis attempts to build them from source.
This fails unless a suitable local version of llvm is available.

It's easier just to tell `pip` to prefer pre-compiled dependencies.

Caused by https://github.com/numba/llvmlite/issues/471