### PR TITLE
Remove the hard-coded citation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,29 @@ Syntax Summary
 For installation instructions, api documention, and tutorials, [head over to our documentation](https://clifford.readthedocs.io/)!
 
 Citing This Library
-----------
-```
+-------------------
+
+As linked at the top of this page, `clifford` is published to zenodo.
+DOI [10.5281/zenodo.1453978](https://doi.org/10.5281/zenodo.1453978) refers to all versions of clifford.
+
+
+To obtain BibTex citation information for a _specific_ release (recommended):
+
+* Run `python -m pip show clifford` to determine which version you are using (or print `clifford.__version__` from python)
+* Click on the corresponding version from [this list of versions](https://zenodo.org/search?page=1&size=20&q=conceptrecid:1453978&sort=-version&all_versions=True)
+* Scroll down to the bottom of the page, and click the "BibTex" link in the "Export" sidebar
+
+If you want to cite all releases, use:
+```tex
 @software{python_clifford,
   author       = {Alex Arsenovic and
                   Hugo Hadfield and
                   Eric Wieser and
                   Robert Kern and
                   {The Pygae Team}},
-  title        = {pygae/clifford v1.3.0dev2},
-  month        = mar,
-  year         = 2020,
+  title        = {pygae/clifford},
   publisher    = {Zenodo},
-  version      = {v1.3.0dev2},
-  doi          = {10.5281/zenodo.3724677},
-  url          = {https://doi.org/10.5281/zenodo.3724677}
+  doi          = {10.5281/zenodo.1453978},
+  url          = {https://doi.org/10.5281/zenodo.1453978}
 }
 ```


### PR DESCRIPTION
While this is nice in the readme, it ends up on PyPI associated with the wrong release.

For lazy people we leave behind citation information for no specific version