### PR TITLE
Revert "Disable epub and PDF builds - no one needs them, and they make the build 3x slower"

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,9 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: false
 
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.8


### PR DESCRIPTION
This reverts commit fae278101436b1a614e8756e2a0555c8dcbe991e.

ReadTheDocs is now configured to use a single sphinx build to generate all three outputs.
As a result, the notebooks should now be run just once.