### PR TITLE
tools.g3c: Invert the relationship between `func` and `val_func` functions

### DIFF
--- a/clifford/tools/g3c/__init__.py
+++ b/clifford/tools/g3c/__init__.py
@@ -927,10 +927,14 @@ def meet(A, B):
 @numba.njit
 @_defunct_wrapper
 def val_intersect_line_and_plane_to_point(line_val, plane_val):
-    return intersect_line_and_plane_to_point(
+    ret = intersect_line_and_plane_to_point(
         layout.MultiVector(line_val),
         layout.MultiVector(plane_val)
-    ).value
+    )
+    if ret is None:
+        return np.array([-1.])
+    else:
+        return ret.value
 
 
 @numba.njit

--- a/clifford/tools/g3c/__init__.py
+++ b/clifford/tools/g3c/__init__.py
@@ -1158,13 +1158,21 @@ def annihilate_k(K, C):
 @numba.njit
 @_defunct_wrapper
 def pos_twiddle_root_val(C_value):
-    return pos_twiddle_root(layout.MultiVector(C_value)).value
+    A, B = pos_twiddle_root(layout.MultiVector(C_value))
+    output = np.zeros((2, 32))
+    output[0, :] = A.value
+    output[1, :] = B.value
+    return output
 
 
 @numba.njit
 @_defunct_wrapper
 def neg_twiddle_root_val(C_value):
-    return neg_twiddle_root(layout.MultiVector(C_value)).value
+    A, B = neg_twiddle_root(layout.MultiVector(C_value))
+    output = np.zeros((2, 32))
+    output[0, :] = A.value
+    output[1, :] = B.value
+    return output
 
 
 @numba.njit


### PR DESCRIPTION
This changes all the algorithms to be implemented using the numba overloading syntax.
This isn't exhaustive, but hits most of the cases.

We can't remove the `val_func` functions until we remove all the callers.

This will probably need quite careful review, as I don't think all these functions are tested. I'll make sure not to do any rebases so that it's easy to keep track of where you get to.