### PR TITLE
tools.g3c: Add jit decorators to all of the `val_` function wrappers

### DIFF
--- a/clifford/tools/g3c/__init__.py
+++ b/clifford/tools/g3c/__init__.py
@@ -195,16 +195,8 @@ I5 = e12345
 I3 = e123
 E0 = ninf ^ -no
 niono = ninf ^ no
-E0_val = E0.value
-I5_val = I5.value
-ninf_val = ninf.value
-no_val = no.value
-I3_val = I3.value
-eo_val = eo.value
 
 unit_scalar_mv = 1.0 + 0.0*e1
-unit_scalar_mv_val = unit_scalar_mv.value
-
 adjoint_func = layout.adjoint_func
 gmt_func = layout.gmt_func
 omt_func = layout.omt_func
@@ -330,7 +322,7 @@ def val_unsign_sphere(S):
     """
     Normalises the sign of a sphere
     """
-    return val_normalised(S*(-imt_func(dual_func(S), ninf_val)[0]))
+    return val_normalised(S*(-imt_func(dual_func(S), ninf.value)[0]))
 
 
 def join_spheres(S1in, S2in):
@@ -661,11 +653,11 @@ def val_get_line_intersection(L3_val, Ldd_val):
     Pd = 0.5*(Xdd+Xddd)
     P = -(Pd*ninf*Pd)(1)/(2*(Pd|einf)**2)[0]
     """
-    Xdd = gmt_func(gmt_func(Ldd_val, no_val), Ldd_val) + no_val
+    Xdd = gmt_func(gmt_func(Ldd_val, no.value), Ldd_val) + no.value
     Xddd = gmt_func(gmt_func(L3_val, Xdd), L3_val)
     Pd = 0.5*(Xdd+Xddd)
-    P = -gmt_func(gmt_func(Pd, ninf_val), Pd)
-    imt_value = imt_func(Pd, ninf_val)
+    P = -gmt_func(gmt_func(Pd, ninf.value), Pd)
+    imt_value = imt_func(Pd, ninf.value)
     P_denominator = 2*(gmt_func(imt_value, imt_value))[0]
     return project_val(P/P_denominator, 1)
 
@@ -690,7 +682,7 @@ def val_midpoint_between_lines(L1_val, L2_val):
     L3 = val_normalised(L1_val + L2_val)
     Ldd = val_normalised(L1_val - L2_val)
     S = val_get_line_intersection(L3, Ldd)
-    return val_normalise_n_minus_1(project_val(gmt_func(S, gmt_func(ninf_val, S)), 1))
+    return val_normalise_n_minus_1(project_val(gmt_func(S, gmt_func(ninf.value, S)), 1))
 
 
 def midpoint_between_lines(L1, L2):
@@ -731,14 +723,14 @@ def val_midpoint_of_line_cluster(array_line_cluster):
     power_mat = np.linalg.matrix_power(accumulator_matrix / array_line_cluster.shape[0], 256)
 
     # Get a point that lies on the first line as an approximation to the e-vector
-    pp_val = imt_func(array_line_cluster[0, :], eo_val)
-    p_start = val_normalise_n_minus_1(project_val(gmt_func(gmt_func(pp_val, ninf_val), pp_val), 1))
+    pp_val = imt_func(array_line_cluster[0, :], eo.value)
+    p_start = val_normalise_n_minus_1(project_val(gmt_func(gmt_func(pp_val, ninf.value), pp_val), 1))
 
     # Apply the matrix
     p_end = project_val(power_mat @ p_start, 1)
 
     # Remove any junk that has come along with it
-    final_point = val_normalise_n_minus_1(project_val(gmt_func(gmt_func(p_end, ninf_val), p_end), 1))
+    final_point = val_normalise_n_minus_1(project_val(gmt_func(gmt_func(p_end, ninf.value), p_end), 1))
     return final_point
 
 
@@ -753,16 +745,16 @@ def val_midpoint_of_line_cluster_grad(array_line_cluster):
     for i in range(array_line_cluster.shape[0]):
         p = val_midpoint_between_lines(average_line, array_line_cluster[i, :])
         val_point_track += p
-    S = gmt_func(I5_val, val_point_track)
-    center_point = val_normalise_n_minus_1(project_val(gmt_func(S, gmt_func(ninf_val, S)), 1))
+    S = gmt_func(I5.value, val_point_track)
+    center_point = val_normalise_n_minus_1(project_val(gmt_func(S, gmt_func(ninf.value, S)), 1))
     # Take a derivative of the cost function at this point
     grad = np.zeros(32)
     for i in range(array_line_cluster.shape[0]):
         l_val = array_line_cluster[i, :]
         grad += (gmt_func(gmt_func(l_val, center_point), l_val))
     grad = val_normalise_n_minus_1(project_val(grad, 1))
-    s_val = gmt_func(I5_val, project_val(center_point + grad, 1))
-    center_point = val_normalise_n_minus_1(gmt_func(gmt_func(s_val, ninf_val), s_val))
+    s_val = gmt_func(I5.value, project_val(center_point + grad, 1))
+    center_point = val_normalise_n_minus_1(gmt_func(gmt_func(s_val, ninf.value), s_val))
     return center_point
 
 
@@ -906,7 +898,7 @@ def val_generate_translation_rotor(euc_vector_a):
     """
     Generates a rotor that translates objects along the euclidean vector euc_vector_a
     """
-    T = gmt_func(ninf_val, euc_vector_a) / 2
+    T = gmt_func(ninf.value, euc_vector_a) / 2
     T[0] += 1
     return T
 
@@ -966,7 +958,7 @@ def val_normalise_n_minus_1(mv_val):
     """
     Normalises a conformal point so that it has an inner product of -1 with einf
     """
-    scale = imt_func(mv_val, ninf_val)[0]
+    scale = imt_func(mv_val, ninf.value)[0]
     if scale != 0.0:
         return -mv_val/scale
     else:
@@ -1019,8 +1011,8 @@ def val_point_pair_to_end_points(T):
     P[0] += 0.5
     P_twiddle = -0.5*F
     P_twiddle[0] += 0.5
-    A = val_normalise_n_minus_1(-gmt_func(P_twiddle, imt_func(T, ninf_val)))
-    B = val_normalise_n_minus_1(gmt_func(P, imt_func(T, ninf_val)))
+    A = val_normalise_n_minus_1(-gmt_func(P_twiddle, imt_func(T, ninf.value)))
+    B = val_normalise_n_minus_1(gmt_func(P, imt_func(T, ninf.value)))
     output = np.zeros((2, 32))
     output[0, :] = A
     output[1, :] = B
@@ -1375,19 +1367,19 @@ def val_motor_between_rounds(X1, X2):
     T = generate_translation_rotor(t)
     return normalised(T*R)
     """
-    F1 = val_normalised(omt_func(X1, ninf_val))
-    F2 = val_normalised(omt_func(X2, ninf_val))
+    F1 = val_normalised(omt_func(X1, ninf.value))
+    F2 = val_normalised(omt_func(X2, ninf.value))
 
     if np.abs(F1[31]) > 1E-5:
         # Its spheres we are dealing with
-        R = unit_scalar_mv_val
+        R = unit_scalar_mv.value
         X3 = X1
     else:
         R = val_rotor_between_objects_root(F1, F2)
         X3 = val_apply_rotor(X1, R)
 
-    C1 = val_normalise_n_minus_1(project_val(gmt_func(gmt_func(X3, ninf_val), X3), 1))
-    C2 = val_normalise_n_minus_1(project_val(gmt_func(gmt_func(X2, ninf_val), X2), 1))
+    C1 = val_normalise_n_minus_1(project_val(gmt_func(gmt_func(X3, ninf.value), X3), 1))
+    C2 = val_normalise_n_minus_1(project_val(gmt_func(gmt_func(X2, ninf.value), X2), 1))
 
     t = np.zeros(32)
     t[1:4] = (C2 - C1)[1:4]
@@ -1400,7 +1392,7 @@ def val_motor_between_objects(X1, X2):
     """
     Calculates a motor that takes X1 to X2
     """
-    carrier = omt_func(X1, ninf_val)
+    carrier = omt_func(X1, ninf.value)
     if np.sum(np.abs(carrier)) < 1E-4:
         # They are flats
         return val_rotor_between_objects_root(X1, X2)
@@ -1525,7 +1517,7 @@ def val_rotor_between_objects_explicit(X1, X2):
     K_val[0] = K_val[0] + 2
 
     if np.sum(np.abs(K_val)) < 0.0000001:
-        return unit_scalar_mv_val
+        return unit_scalar_mv.value
 
     if np.sum(np.abs(project_val(M12_val, 4))) > 0.00001:
         K_val_4 = project_val(K_val, 4)
@@ -1761,7 +1753,7 @@ def apply_rotor_inv(mv_in, rotor, rotor_inv):
 @numba.njit
 def mult_with_ninf(mv):
     """ Convenience function for multiplication with ninf """
-    return gmt_func(mv, ninf_val)
+    return gmt_func(mv, ninf.value)
 
 
 # @numba.njit
@@ -1777,7 +1769,7 @@ def val_convert_2D_polar_line_to_conformal_line(rho, theta):
     y2 = int(y0 - 10000 * (a))
     p1_val = val_convert_2D_point_to_conformal(x1, y1)
     p2_val = val_convert_2D_point_to_conformal(x2, y2)
-    line_val = omt_func(omt_func(p1_val, p2_val), ninf_val)
+    line_val = omt_func(omt_func(p1_val, p2_val), ninf.value)
     line_val = line_val/abs(layout.MultiVector(line_val))
     return line_val
 
@@ -1793,7 +1785,7 @@ def val_up(mv_val):
     """ Fast jitted up mapping """
     temp = np.zeros(32)
     temp[0] = 0.5
-    return mv_val - no_val + omt_func(temp, gmt_func(gmt_func(mv_val, mv_val), ninf_val))
+    return mv_val - no.value + omt_func(temp, gmt_func(gmt_func(mv_val, mv_val), ninf.value))
 
 
 def fast_up(mv):
@@ -1812,13 +1804,13 @@ def val_normalInv(mv_val):
 @numba.njit
 def val_homo(mv_val):
     """ A fast, jitted version of homo() """
-    return gmt_func(mv_val, val_normalInv(imt_func(-mv_val, ninf_val)))
+    return gmt_func(mv_val, val_normalInv(imt_func(-mv_val, ninf.value)))
 
 
 @numba.njit
 def val_down(mv_val):
     """ A fast, jitted version of down() """
-    return gmt_func(omt_func(val_homo(mv_val), E0_val), E0_val)
+    return gmt_func(omt_func(val_homo(mv_val), E0.value), E0.value)
 
 
 def fast_down(mv):
@@ -1862,7 +1854,7 @@ def dual_func(a_val):
     """
     Fast dual
     """
-    return dual_gmt_func(I5_val, a_val)
+    return dual_gmt_func(I5.value, a_val)
 
 
 def fast_dual(a):

--- a/clifford/tools/g3c/__init__.py
+++ b/clifford/tools/g3c/__init__.py
@@ -310,6 +310,7 @@ def point_beyond_plane(point, plane):
     return (point|(I5*plane))[0] < 0
 
 
+@numba.njit
 def unsign_sphere(S):
     """
     Normalises the sign of a sphere
@@ -662,6 +663,7 @@ def val_get_line_intersection(L3_val, Ldd_val):
     return project_val(P/P_denominator, 1)
 
 
+@numba.njit
 def get_line_intersection(L3, Ldd):
     """
     Gets the point of intersection of two orthogonal lines that meet
@@ -685,6 +687,7 @@ def val_midpoint_between_lines(L1_val, L2_val):
     return val_normalise_n_minus_1(project_val(gmt_func(S, gmt_func(ninf.value, S)), 1))
 
 
+@numba.njit
 def midpoint_between_lines(L1, L2):
     """
     Gets the point that is maximally close to both lines
@@ -693,6 +696,7 @@ def midpoint_between_lines(L1, L2):
     return layout.MultiVector(val_midpoint_between_lines(L1.value, L2.value))
 
 
+@numba.njit
 def midpoint_of_line_cluster(line_cluster):
     """
     Gets a center point of a line cluster
@@ -886,6 +890,7 @@ def generate_dilation_rotor(scale):
     return math.cosh(gamma/2) + math.sinh(gamma/2)*(ninf^no)
 
 
+@numba.njit
 def generate_translation_rotor(euc_vector_a):
     """
     Generates a rotor that translates objects along the euclidean vector euc_vector_a
@@ -912,6 +917,7 @@ def meet_val(a_val, b_val):
     return dual_func(omt_func(dual_func(a_val), dual_func(b_val)))
 
 
+@numba.njit
 def meet(A, B):
     """
     The meet algorithm as described in "A Covariant Approach to Geometry"
@@ -942,6 +948,7 @@ def val_intersect_line_and_plane_to_point(line_val, plane_val):
     return output
 
 
+@numba.njit
 def intersect_line_and_plane_to_point(line, plane):
     """
     Returns the point at the intersection of a line and plane
@@ -965,6 +972,7 @@ def val_normalise_n_minus_1(mv_val):
         raise ZeroDivisionError('Multivector has 0 einf component')
 
 
+@numba.njit
 def normalise_n_minus_1(mv):
     """
     Normalises a conformal point so that it has an inner product of -1 with einf
@@ -1019,6 +1027,7 @@ def val_point_pair_to_end_points(T):
     return output
 
 
+@numba.njit
 def point_pair_to_end_points(T):
     """
     Extracts the end points of a point pair bivector
@@ -1052,6 +1061,7 @@ def check_sigma_for_positive_root_val(sigma_val):
     return (sigma_val[0] + dorst_norm_val(sigma_val)) > 0
 
 
+@numba.njit
 def check_sigma_for_positive_root(sigma):
     """ Square Root of Rotors - Checks for a positive root """
     return check_sigma_for_positive_root_val(sigma.value)
@@ -1063,6 +1073,7 @@ def check_sigma_for_negative_root_val(sigma_value):
     return (sigma_value[0] - dorst_norm_val(sigma_value)) > 0
 
 
+@numba.njit
 def check_sigma_for_negative_root(sigma):
     """ Square Root of Rotors - Checks for a negative root """
     return check_sigma_for_negative_root_val(sigma.value)
@@ -1074,6 +1085,7 @@ def check_infinite_roots_val(sigma_value):
     return (sigma_value[0] + dorst_norm_val(sigma_value)) < 0.0000000001
 
 
+@numba.njit
 def check_infinite_roots(sigma):
     """ Square Root of Rotors - Checks for a infinite roots """
     return check_infinite_roots_val(sigma.value)
@@ -1104,6 +1116,7 @@ def negative_root_val(sigma_val):
     return result
 
 
+@numba.njit
 def positive_root(sigma):
     """
     Square Root of Rotors - Evaluates the positive root
@@ -1112,6 +1125,7 @@ def positive_root(sigma):
     return layout.MultiVector(res_val)
 
 
+@numba.njit
 def negative_root(sigma):
     """ Square Root of Rotors - Evaluates the negative root """
     res_val = negative_root_val(sigma.value)
@@ -1146,6 +1160,7 @@ def general_root_val(sigma_value):
         raise ValueError('No root exists')
 
 
+@numba.njit
 def general_root(sigma):
     """ The general case of the root of a grade 0, 4 multivector """
     output = general_root_val(sigma.value)
@@ -1160,6 +1175,7 @@ def val_annihilate_k(K_val, C_val):
     return val_normalised(gmt_func(k_4, C_val))
 
 
+@numba.njit
 def annihilate_k(K, C):
     """ Removes K from C = KX via (K[0] - K[4])*C """
     return layout.MultiVector(val_annihilate_k(K.value, C.value))
@@ -1197,6 +1213,7 @@ def neg_twiddle_root_val(C_value):
     return output
 
 
+@numba.njit
 def pos_twiddle_root(C):
     """
     Square Root and Logarithm of Rotors
@@ -1208,6 +1225,7 @@ def pos_twiddle_root(C):
     return [layout.MultiVector(output[0, :]), layout.MultiVector(output[1, :])]
 
 
+@numba.njit
 def neg_twiddle_root(C):
     """
     Square Root and Logarithm of Rotors
@@ -1342,6 +1360,7 @@ def TRS_between_rounds(X1, X2):
     return normalised((~T2)*S*Rc*T1)
 
 
+@numba.njit
 def motor_between_rounds(X1, X2):
     """
     Calculate the motor between any pair of rounds of the same grade
@@ -1401,6 +1420,7 @@ def val_motor_between_objects(X1, X2):
         return val_motor_between_rounds(X1, X2)
 
 
+@numba.njit
 def motor_between_objects(X1, X2):
     """
     Calculates a motor that takes X1 to X2
@@ -1551,6 +1571,7 @@ def val_norm(mv_val):
     return np.sqrt(np.abs(gmt_func(adjoint_func(mv_val), mv_val)[0]))
 
 
+@numba.njit
 def norm(mv):
     """ Returns sqrt(abs(~A*A)) """
     return val_norm(mv.value)
@@ -1562,6 +1583,7 @@ def val_normalised(mv_val):
     return mv_val/val_norm(mv_val)
 
 
+@numba.njit
 def normalised(mv):
     """ fast version of the normal() function """
     return layout.MultiVector(val_normalised(mv.value))
@@ -1587,11 +1609,13 @@ def val_rotor_between_lines(L1_val, L2_val):
     return gmt_func(normalisation_val, output_val)
 
 
+@numba.njit
 def rotor_between_lines(L1, L2):
     """ return the rotor between two lines """
     return layout.MultiVector(val_rotor_between_lines(L1.value, L2.value))
 
 
+@numba.njit
 def rotor_between_planes(P1, P2):
     """ return the rotor between two planes """
     return layout.MultiVector(val_rotor_rotor_between_planes(P1.value, P2.value))
@@ -1734,6 +1758,7 @@ def val_apply_rotor(mv_val, rotor_val):
     return gmt_func(rotor_val, gmt_func(mv_val, adjoint_func(rotor_val)))
 
 
+@numba.njit
 def apply_rotor(mv_in, rotor):
     """ Applies rotor to multivector in a fast way """
     return layout.MultiVector(val_apply_rotor(mv_in.value, rotor.value))
@@ -1745,6 +1770,7 @@ def val_apply_rotor_inv(mv_val, rotor_val, rotor_val_inv):
     return gmt_func(rotor_val, gmt_func(mv_val, rotor_val_inv))
 
 
+@numba.njit
 def apply_rotor_inv(mv_in, rotor, rotor_inv):
     """ Applies rotor to multivector in a fast way takes pre computed adjoint"""
     return layout.MultiVector(val_apply_rotor_inv(mv_in.value, rotor.value, rotor_inv.value))
@@ -1774,6 +1800,7 @@ def val_convert_2D_polar_line_to_conformal_line(rho, theta):
     return line_val
 
 
+@numba.njit
 def convert_2D_polar_line_to_conformal_line(rho, theta):
     """ Converts a 2D polar line to a conformal line """
     line_val = val_convert_2D_polar_line_to_conformal_line(rho, theta)
@@ -1788,6 +1815,7 @@ def val_up(mv_val):
     return mv_val - no.value + omt_func(temp, gmt_func(gmt_func(mv_val, mv_val), ninf.value))
 
 
+@numba.njit
 def fast_up(mv):
     """ Fast up mapping """
     return layout.MultiVector(val_up(mv.value))
@@ -1813,6 +1841,7 @@ def val_down(mv_val):
     return gmt_func(omt_func(val_homo(mv_val), E0.value), E0.value)
 
 
+@numba.njit
 def fast_down(mv):
     """ A fast version of down() """
     return layout.MultiVector(val_down(mv.value))
@@ -1834,6 +1863,7 @@ def val_convert_2D_point_to_conformal(x, y):
     return val_up(mv_val)
 
 
+@numba.njit
 def convert_2D_point_to_conformal(x, y):
     """ Convert a 2D point to conformal """
     return layout.MultiVector(val_convert_2D_point_to_conformal(x, y))
@@ -1857,6 +1887,7 @@ def dual_func(a_val):
     return dual_gmt_func(I5.value, a_val)
 
 
+@numba.njit
 def fast_dual(a):
     """
     Fast dual

--- a/clifford/tools/g3c/cost_functions.py
+++ b/clifford/tools/g3c/cost_functions.py
@@ -7,9 +7,6 @@ from .rotor_parameterisation import general_logarithm
 imt_func = layout.imt_func
 gmt_func = layout.gmt_func
 adjoint_func = layout.adjoint_func
-e4_val = e4.value
-e5_val = e5.value
-ninf_val = einf.value
 
 
 sparse_cost_imt = layout.imt_func_generator(grades_a=[0, 2, 4], grades_b=[1])
@@ -61,8 +58,8 @@ def midpoint_and_error_of_line_cluster_eig(line_cluster):
     """
     line_cluster_array = np.array([l.value for l in line_cluster], dtype=np.float64)
     mat2solve = val_truncated_get_line_reflection_matrix(line_cluster_array, 128)
-    start = imt_func(no_val, sum(l.value for l in line_cluster))
-    start = gmt_func(gmt_func(start, ninf_val), start)[1:6]
+    start = imt_func(no.value, sum(l.value for l in line_cluster))
+    start = gmt_func(gmt_func(start, ninf.value), start)[1:6]
 
     point_val = np.zeros(32)
     point_val[1:6] = np.matmul(mat2solve, start)
@@ -153,7 +150,7 @@ def val_rotor_cost_sparse(R_val):
     """
     rotation_val = R_val.copy()
     rotation_val[0] -= 1
-    translation_val = sparse_cost_imt(R_val, e4_val)
+    translation_val = sparse_cost_imt(R_val, e4.value)
     a = abs(float(sparse_cost_gmt(rotation_val, adjoint_func(rotation_val))[0]))
     b = abs(float(gmt_func(translation_val, adjoint_func(translation_val))[0]))
     return a + b

--- a/clifford/tools/g3c/object_fitting.py
+++ b/clifford/tools/g3c/object_fitting.py
@@ -80,7 +80,7 @@ def val_fit_line(point_list):
         best_obj = point_list[0, :]
         for i in range(1, 2):
             best_obj = omt_func(best_obj, point_list[i, :])
-        return val_normalised(omt_func(best_obj, ninf_val))
+        return val_normalised(omt_func(best_obj, ninf.value))
     accumulator_matrix = np.zeros((32, 32))
     for i in range(point_list.shape[0]):
         P_i_l = get_left_gmt_matrix(point_list[i, :])
@@ -95,7 +95,7 @@ def val_fit_line(point_list):
         if e_vals[i] < min_eval and e_vals[i] > 0:
             min_eval = e_vals[i]
             min_eval_index = i
-    best_line = mask3@omt_func(dual_func(e_vecs[:, min_eval_index]), ninf_val)
+    best_line = mask3@omt_func(dual_func(e_vecs[:, min_eval_index]), ninf.value)
     return val_normalised(best_line)
 
 
@@ -155,7 +155,7 @@ def val_fit_plane(point_list):
         best_obj = point_list[0, :]
         for i in range(1, 3):
             best_obj = omt_func(best_obj, point_list[i, :])
-        return val_normalised(omt_func(best_obj, ninf_val))
+        return val_normalised(omt_func(best_obj, ninf.value))
     accumulator_matrix = np.zeros((32, 32))
     for i in range(point_list.shape[0]):
         P_i_l = get_left_gmt_matrix(point_list[i, :])

--- a/clifford/tools/g3c/rotor_estimation.py
+++ b/clifford/tools/g3c/rotor_estimation.py
@@ -19,8 +19,6 @@ imt_func = layout.imt_func
 gmt_func = layout.gmt_func
 inv_func = layout.inv_func
 adjoint_func = layout.adjoint_func
-e4_val = e4.value
-ninf_val = einf.value
 e123inf = e123*einf
 
 motor_basis = [1 + 0 * e1, e12, e13, e23,
@@ -156,10 +154,7 @@ def val_in_plane_estimate_rotation(bv, A, Y):
     return adjoint_func(val_normalised(R))
 
 
-e23_val = e23.value
-e12_val = e12.value
-e13_val = e13.value
-dekeninckbivmat = np.array([e23_val, e12_val, e13_val])
+dekeninckbivmat = np.array([e23.value, e12.value, e13.value])
 
 
 @numba.njit

--- a/clifford/tools/g3c/rotor_parameterisation.py
+++ b/clifford/tools/g3c/rotor_parameterisation.py
@@ -16,11 +16,6 @@ unit_scalar_mv = 1.0 + 0.0*e1
 imt_func = layout.imt_func
 gmt_func = layout.gmt_func
 adjoint_func = layout.adjoint_func
-e4_val = e4.value
-ninf_val = einf.value
-I5_val = I5.value
-no_val = no.value
-I3_val = I3.value
 
 
 def dorst_sinh(A):
@@ -172,13 +167,13 @@ def val_exp(B_val):
     """
     Fast implementation of the translation and rotation specific exp function
     """
-    t_val = imt_func(B_val, no_val)
+    t_val = imt_func(B_val, no.value)
 
     phiP_val = B_val - mult_with_ninf(t_val)
     phi = np.sqrt(-float(gmt_func(phiP_val, phiP_val)[0]))
     P_val = phiP_val / phi
 
-    P_n_val = gmt_func(P_val, I3_val)
+    P_n_val = gmt_func(P_val, I3.value)
     t_nor_val = gmt_func(imt_func(t_val, P_n_val), P_n_val)
     t_par_val = t_val - t_nor_val
 
@@ -268,7 +263,7 @@ def val_vec_repr_to_bivector(x):
     t_val[1] = x[0]
     t_val[2] = x[1]
     t_val[3] = x[2]
-    B_val = gmt_func(t_val, ninf_val)
+    B_val = gmt_func(t_val, ninf.value)
     B_val[6] += x[3]
     B_val[7] += x[4]
     B_val[10] += x[5]


### PR DESCRIPTION
This means there is no longer any reason to call the `val` versions from other code.