### PR TITLE
Add the closed form inverse for total dimension <= 5

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -459,6 +459,18 @@ class Layout(object):
             return dual_func
 
     @_cached_property
+    def _grade_invol(self):
+        """
+        Generates the grade involution function
+        """
+        signs = np.power(-1, self._basis_blade_order.grades)
+        @_numba_utils.njit
+        def grade_inv_func(mv):
+            newValue = signs * mv.value
+            return self.MultiVector(newValue)
+        return grade_inv_func
+
+    @_cached_property
     def vee_func(self):
         """
         Generates the vee product function

--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -716,6 +716,9 @@ class MultiVector(object):
 
         return self / abs(self)
 
+    def hitzer_inverse(self):
+        return self.layout._hitzer_inverse(self)
+
     def leftLaInv(self) -> 'MultiVector':
         """Return left-inverse using a computational linear algebra method
         proposed by Christian Perwass.
@@ -729,14 +732,17 @@ class MultiVector(object):
         ----------
         fallback : bool, optional
             If `None`, perform no checks on whether normal inv is appropriate.
-            If `True`, fallback to a linalg approach if necessary.
+            If `True`, fallback to a Hitzer and Sangwine's method :cite:`Hitzer_Sangwine_2017` if possible and a linalg approach if not.
             If `False`, raise an error if normal inv is not appropriate.
         """
         Madjoint = ~self
         MadjointM = (Madjoint * self)
         if fallback is not None and not MadjointM.isScalar():
             if fallback:
-                return self.leftLaInv()
+                try:
+                    return self.hitzer_inverse()
+                except NotImplementedError:
+                    return self.leftLaInv()
             else:
                 raise ValueError("no inverse exists for this multivector")
 

--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -801,12 +801,7 @@ class MultiVector(object):
             M^* = \sum_{i=0}^{\text{dims}}
                   {(-1)^i \left<M\right>_i}
         """
-
-        signs = np.power(-1, self.layout._basis_blade_order.grades)
-
-        newValue = signs * self.value
-
-        return self._newMV(newValue)
+        return self.layout._grade_invol(self)
 
     @property
     def even(self) -> 'MultiVector':

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -337,3 +337,16 @@ def MultiVector___abs__(self):
 @numba.extending.overload_method(MultiVectorType, 'normal')
 def MultiVector_normal(self):
     return MultiVector.normal
+
+
+@numba.extending.overload_method(MultiVectorType, 'gradeInvol')
+def MultiVector_gradeInvol(self):
+    g_func = self.layout_type.obj._grade_invol
+    def impl(self):
+        return g_func(self)
+    return impl
+
+
+@numba.extending.overload_method(MultiVectorType, 'conjugate')
+def MultiVector_conjugate(self):
+    return MultiVector.conjugate

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -60,7 +60,7 @@ class TestClifford:
             1 / a
         for i in range(10):
             a = randomMV(layout, grades=[0, 1])
-            denominator = float(a(1)**2-a(0)**2)
+            denominator = (a(1)**2)[()]-(a[()]**2)
             if abs(denominator) > 1.e-5:
                 a_inv = (-a(0)/denominator) + ((1./denominator) * a(1))
                 assert abs((a * a_inv)-1.) < 1.e-11

--- a/clifford/test/test_multivector_inverse.py
+++ b/clifford/test/test_multivector_inverse.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+import clifford as cf
+
+
+class TestClosedForm:
+
+    @pytest.mark.parametrize('p, q', [
+        (p, total_dims - p)
+        for total_dims in [1, 2, 3, 4, 5]
+        for p in range(total_dims + 1)
+    ])
+    def test_hitzer_inverse(self, p, q):
+        Ntests = 100
+        layout, blades = cf.Cl(p, q)
+        for i in range(Ntests):
+            mv = layout.randomMV()
+            mv_inv = mv.hitzer_inverse()
+            assert np.all(np.abs(((mv * mv_inv) - 1.).value) < 1.e-11)

--- a/clifford/test/test_multivector_inverse.py
+++ b/clifford/test/test_multivector_inverse.py
@@ -17,4 +17,5 @@ class TestClosedForm:
         for i in range(Ntests):
             mv = layout.randomMV()
             mv_inv = mv.hitzer_inverse()
-            assert np.all(np.abs(((mv * mv_inv) - 1.).value) < 1.e-11)
+            np.testing.assert_almost_equal((mv * mv_inv).value,
+                                           (1.0 + 0*blades["e1"]).value)

--- a/clifford/test/test_multivector_inverse.py
+++ b/clifford/test/test_multivector_inverse.py
@@ -18,4 +18,4 @@ class TestClosedForm:
             mv = layout.randomMV()
             mv_inv = mv.hitzer_inverse()
             np.testing.assert_almost_equal((mv * mv_inv).value,
-                                           (1.0 + 0*blades["e1"]).value)
+                                           layout.scalar.value)

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -62,3 +62,16 @@
     journal = {Advances in Applied Clifford Algebras},
     doi = {10.1007/s00006-019-1003-y}
 }
+
+@article{Hitzer_Sangwine_2017,
+    title = {Multivector and multivector matrix inverses in real Clifford algebras},
+    volume = {311},
+    ISSN = {0096-3003},
+    DOI = {10.1016/j.amc.2017.05.027},
+    abstractNote = {We show how to compute the inverse of multivectors in finite dimensional real Clifford algebras Cl(p, q). For algebras over vector spaces of fewer than six dimensions, we provide explicit formulae for discriminating between divisors of zero and invertible multivectors, and for the computation of the inverse of a general invertible multivector. For algebras over vector spaces of dimension six or higher, we use isomorphisms between algebras, and between multivectors and matrix representations with multivector elements in Clifford algebras of lower dimension. Towards this end we provide explicit details of how to compute several forms of isomorphism that are essential to invert multivectors in arbitrarily chosen algebras. We also discuss briefly the computation of the inverses of matrices of multivectors by adapting an existing textbook algorithm for matrices to the multivector setting, using the previous results to compute the required inverses of individual multivectors.},
+    journal = {Applied Mathematics and Computation},
+    author = {Hitzer, Eckhard and Sangwine, Stephen},
+    year = {2017},
+    month = {Oct},
+    pages = {375–389}
+}


### PR DESCRIPTION
Implements the inverse given in:
[Multivector and multivector matrix inverses in real Clifford algebras 
Eckhard Hitzer, Stephen Sangwine (2017)](http://repository.essex.ac.uk/17282/1/TechReport_CES-534.pdf)

This method is a speed up over the linear algebra method even without JITing.

Note this does not do the higher dimension inverses based on clifford valued matrix isomorphism described in the paper.

Ideas for testing the numerical stability vs the linear algebra method would be very welcome.
