### PR TITLE
Do not convert gradeList back and forth between list and ndarray

### DIFF
--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -273,7 +273,7 @@ def grade_obj(objin, threshold=0.0000001):
     '''
     Returns the modal grade of a multivector
     '''
-    return grade_obj_func(objin.value, np.asarray(objin.layout.gradeList), threshold)
+    return grade_obj_func(objin.value, objin.layout._basis_blade_order.grades, threshold)
 
 
 def grades_present(objin: 'MultiVector', threshold=0.0000001) -> Set[int]:
@@ -407,7 +407,7 @@ def randomMV(
             grades = [grades]
         newValue = np.zeros((layout.gaDims,))
         for i in range(layout.gaDims):
-            if layout.gradeList[i] in grades:
+            if layout._basis_blade_order.grades[i] in grades:
                 newValue[i] = uniform(min, max)
         mv = mvClass(layout, newValue)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,12 @@
 Changelog
 =========
 
+Changes in 1.4.x
+++++++++++++++++
+
+ * Projection using :meth:`Multivector.__call__` no longer raises :exc:`ValueError`
+   for grades not present in the algebra, and instead just returns zero.
+
 Changes in 1.3.x
 ++++++++++++++++
 


### PR DESCRIPTION
This should be a marginal performance boost, but the main goal is to reduce the amount of similar state in `Layout`.

This also changes `mv(n+1)` to return 0 in an `n`-d algebra. This makes it a little more convenient to treat `G(3)` as a subalgebra of `G(4)` etc.