### PR TITLE
Deprecate the sequence-like methods of MultiVector

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -667,7 +667,7 @@ class Layout(object):
             self._metric = np.zeros((len(basis_vectors), len(basis_vectors)))
             for i, v in enumerate(basis_vectors):
                 for j, v2 in enumerate(basis_vectors):
-                    self._metric[i, j] = (v | v2)[0]
+                    self._metric[i, j] = (v | v2)[()]
             return self._metric.copy()
         else:
             return self._metric.copy()

--- a/clifford/_parser.py
+++ b/clifford/_parser.py
@@ -105,11 +105,11 @@ def parse_multivector(layout: Layout, mv_string: str) -> MultiVector:
             coeff = data
 
         elif t == 'blade' and last_t == 'wedge':
-            mv_out[data] += coeff
+            mv_out.value[data] += coeff
         elif t == 'blade' and last_t == 'sign':
-            mv_out[data] += sign
+            mv_out.value[data] += sign
         elif t == 'blade' and last_t is None:
-            mv_out[data] += 1
+            mv_out.value[data] += 1
 
         elif t == 'wedge' and last_t == 'coeff':
             pass

--- a/clifford/dg3c.py
+++ b/clifford/dg3c.py
@@ -47,7 +47,7 @@ def down_cga1(point_cga1):
     """
     Take a point in CGA
     """
-    return (point_cga1/-(point_cga1|einf1)[0]).value[1:4]
+    return (point_cga1/-(point_cga1|einf1)[()]).value[1:4]
 
 
 def up_cga2(pnt_vector):

--- a/clifford/dpga.py
+++ b/clifford/dpga.py
@@ -52,7 +52,7 @@ def up(threedDvec):
 
 
 def down(pnt):
-    return np.array([(pnt|wis)[0] for wis in [w1s, w2s, w3s]])/((pnt|w0s)[0])
+    return np.array([(pnt|wis)[()] for wis in [w1s, w2s, w3s]])/((pnt|w0s)[()])
 
 
 def dual_point(point):

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -487,11 +487,11 @@ class TestBasicConformal41:
         e4 = layout.blades['e4']
         e5 = layout.blades['e5']
 
-        assert (e1 * e1)[0] == 1
-        assert (e2 * e2)[0] == 1
-        assert (e3 * e3)[0] == 1
-        assert (e4 * e4)[0] == 1
-        assert (e5 * e5)[0] == -1
+        assert (e1 * e1)[()] == 1
+        assert (e2 * e2)[()] == 1
+        assert (e3 * e3)[()] == 1
+        assert (e4 * e4)[()] == 1
+        assert (e5 * e5)[()] == -1
 
     def test_vee(self, g3c):
         layout = g3c

--- a/clifford/test/test_dpga.py
+++ b/clifford/test/test_dpga.py
@@ -15,7 +15,7 @@ class TestBasicDPGA:
 
         w_metric = np.array([
             [
-                (a | b)[0]
+                (a | b)[()]
                 for a in wbasis
             ]
             for b in wbasis

--- a/clifford/test/test_g3c_tools.py
+++ b/clifford/test/test_g3c_tools.py
@@ -622,7 +622,7 @@ class TestG3CTools:
         for i in range(500):
             mv = np.random.rand() * random_conformal_point()
             mv_normed = normalise_n_minus_1(mv)
-            npt.assert_almost_equal((mv_normed | ninf)[0], -1.0)
+            npt.assert_almost_equal((mv_normed | ninf)[()], -1.0)
 
     def test_get_properties_of_sphere(self):
         for i in range(100):

--- a/clifford/tools/g3/__init__.py
+++ b/clifford/tools/g3/__init__.py
@@ -62,7 +62,7 @@ def quaternion_to_rotor(quaternion):
     Q = layout.MultiVector()
     Q.value[1:4] = quaternion[1:4]
     Q = -e123*Q
-    Q[0] = quaternion[0]
+    Q.value[0] = quaternion[0]
     return Q
 
 
@@ -71,7 +71,7 @@ def rotor_to_quaternion(R):
     Converts a pure rotation rotor into a quaternion
     """
     Q = (e123*R).value[0:4]
-    Q[0] = R[0]
+    Q[0] = R.value[0]
     return Q
 
 
@@ -167,7 +167,7 @@ def generate_rotation_rotor(theta, euc_vector_m, euc_vector_n):
     euc_vector_n = euc_vector_n / abs(euc_vector_n)
     euc_vector_m = euc_vector_m / abs(euc_vector_m)
     bivector_B = (euc_vector_m ^ euc_vector_n)
-    bivector_B = bivector_B / (math.sqrt((-bivector_B * bivector_B)[0]))
+    bivector_B = bivector_B / (math.sqrt((-bivector_B * bivector_B)[()]))
     rotor = math.cos(theta / 2) - bivector_B * math.sin(theta / 2)
     return rotor
 
@@ -181,7 +181,7 @@ def angle_between_vectors(v1, v2):
     """
     Returns the angle between two conformal vectors
     """
-    clipped = np.clip((v1 | v2)[0], -1.0, 1.0)
+    clipped = np.clip((v1 | v2)[()], -1.0, 1.0)
     return math.acos(clipped)
 
 
@@ -196,7 +196,7 @@ def np_to_euc_mv(np_in):
 
 def euc_mv_to_np(euc_point):
     """ Converts a 3d GA point to a 3d numpy vector """
-    return euc_point[1:4].copy()
+    return euc_point.value[1:4].copy()
 
 
 def euc_cross_prod(euc_a, euc_b):

--- a/clifford/tools/g3c/__init__.py
+++ b/clifford/tools/g3c/__init__.py
@@ -257,7 +257,7 @@ def interpret_multivector_as_object(mv):
             else:
                 return 5  # Line
         elif grade == 4:  # Sphere or plane
-            if abs(((mv*I5)|no)[0]) > epsilon:
+            if abs(((mv*I5)|no)[()]) > epsilon:
                 return 7  # Plane
             else:
                 return 6  # Sphere
@@ -286,9 +286,9 @@ def sphere_line_intersect(s, l):
 def sphere_in_sphere(S1, S2, tolerance=10**-6):
     """
     Checks if one sphere is inside the other
-    (S1|S2)[0] < -1
+    (S1|S2)[()] < -1
     """
-    return (unsign_sphere(S1)|unsign_sphere(S2))[0] <= -1 + tolerance
+    return (unsign_sphere(S1)|unsign_sphere(S2))[()] <= -1 + tolerance
 
 
 def sphere_beyond_plane(sphere, plane):
@@ -296,7 +296,7 @@ def sphere_beyond_plane(sphere, plane):
     Check if the sphere is fully beyond the plane in the direction of
     the plane normal
     """
-    no_intersection = ((meet(sphere, plane) ** 2)[0] < 0)
+    no_intersection = ((meet(sphere, plane) ** 2)[()] < 0)
     return no_intersection and point_beyond_plane(normalise_n_minus_1((sphere * einf * sphere)(1)), plane)
 
 
@@ -305,7 +305,7 @@ def sphere_behind_plane(sphere, plane):
     Check if the sphere is fully behind the plane in the direction of
     the plane normal, ie the opposite of sphere_beyond_plane
     """
-    no_intersection = ((meet(sphere, plane) ** 2)[0] < 0)
+    no_intersection = ((meet(sphere, plane) ** 2)[()] < 0)
     return no_intersection and not point_beyond_plane(normalise_n_minus_1((sphere * einf * sphere)(1)), plane)
 
 
@@ -314,7 +314,7 @@ def point_beyond_plane(point, plane):
     Check if the point is fully beyond the plane in the direction of
     the plane normal
     """
-    return (point|(I5*plane))[0] < 0
+    return (point|(I5*plane))[()] < 0
 
 
 @numba.njit
@@ -342,9 +342,9 @@ def join_spheres(S1in, S2in):
     pp2 = (meet(s2, L)(2)).normal()
     p1 = point_pair_to_end_points(pp1)[0]
     p2 = point_pair_to_end_points(pp2)[1]
-    if (p1|(s2*I5))[0] > 0.0:
+    if (p1|(s2*I5))[()] > 0.0:
         opt_sphere = s2(4)
-    elif (p2|(s1*I5))[0] > 0.0:
+    elif (p2|(s1*I5))[()] > 0.0:
         opt_sphere = s1(4)
     else:
         p12 = p1 ^ p2
@@ -434,7 +434,7 @@ def iterative_closest_points_on_circles(C1, C2, niterations=20):
     P_list = point_pair_to_end_points(PP)
     dmin = np.inf
     for Ptest in P_list:
-        d = -(project_points_to_circle([Ptest], C1)[0](1)|project_points_to_circle([Ptest], C2)[0](1))[0]
+        d = -(project_points_to_circle([Ptest], C1)[0](1)|project_points_to_circle([Ptest], C2)[0](1))[()]
         if d < dmin:
             dmin = d
             P2 = Ptest
@@ -467,7 +467,7 @@ def closest_point_on_circle_from_line(C, L, eps=1E-6):
     B = meet(L, phi)
     A = normalise_n_minus_1((C * einf * C)(1))
     bound_sphere = ((C * phi) * I5).normal()
-    if abs((B**2)[0]) < eps:
+    if abs((B**2)[()]) < eps:
         # The line and plane of the circle are parallel
         # Project the line into the plane
         Lpln = (L.normal() + (phi*L*phi)(3).normal()).normal()
@@ -489,7 +489,7 @@ def closest_point_on_circle_from_line(C, L, eps=1E-6):
 
     # If Y is in the sphere that C is the equator of
     if sphere_in_sphere(Y*I5, bound_sphere):
-        if abs((A | P)[0]) < eps:
+        if abs((A | P)[()]) < eps:
             # Just project the line
             L2 = (L.normal() + (phi * L * phi)(3).normal())
             if abs(L2) < eps:
@@ -497,7 +497,7 @@ def closest_point_on_circle_from_line(C, L, eps=1E-6):
                 L2 = (A ^ project_points_to_circle([random_conformal_point()], C)[0] ^ einf).normal()
             else:
                 L2 = L2.normal()
-        elif abs((P | Y)[0]) < eps:
+        elif abs((P | Y)[()]) < eps:
             # Line is perpendicular to the plane of the circle
             L2 = A ^ Y ^ einf
         else:
@@ -506,7 +506,7 @@ def closest_point_on_circle_from_line(C, L, eps=1E-6):
         L2 = A ^ Y ^ einf
     PP = meet(L2, bound_sphere)
     Xs = point_pair_to_end_points(PP)
-    return max(Xs, key=lambda x: (x | P)[0])
+    return max(Xs, key=lambda x: (x | P)[()])
 
 
 def iterative_closest_points_circle_line(C, L, niterations=20):
@@ -527,7 +527,7 @@ def iterative_closest_points_circle_line(C, L, niterations=20):
     P_list = point_pair_to_end_points(PP)
     dmin = np.inf
     for Ptest in P_list:
-        d = -(project_points_to_circle([Ptest], C)[0](1)|project_points_to_line([Ptest], L)[0](1))[0]
+        d = -(project_points_to_circle([Ptest], C)[0](1)|project_points_to_line([Ptest], L)[0](1))[()]
         if d < dmin:
             dmin = d
             P2 = Ptest
@@ -766,9 +766,9 @@ def get_circle_in_euc(circle):
     Ic = (circle^ninf).normal()
     GAnormal = get_plane_normal(Ic)
     inPlaneDual = circle*Ic
-    mag = float((inPlaneDual|ninf)[0])
+    mag = (inPlaneDual|ninf)[()]
     inPlaneDual = -inPlaneDual/mag
-    radius_squared = (inPlaneDual*inPlaneDual)[0]
+    radius_squared = (inPlaneDual*inPlaneDual)[()]
     radius = math.sqrt(abs(radius_squared))
     if radius_squared < 0:
         # We have an imaginary circle, return it as a negative radius as our signal
@@ -800,7 +800,7 @@ def line_to_point_and_direction(line):
 
 def get_plane_origin_distance(plane):
     """ Get the distance between a given plane and the origin """
-    return float(((plane*I5)|no)[0])
+    return ((plane*I5)|no)[()]
 
 
 def get_plane_normal(plane):
@@ -982,7 +982,7 @@ def get_radius_from_sphere(sphere):
     Returns the radius of a sphere
     """
     dual_sphere = sphere * I5
-    dual_sphere = dual_sphere / (-dual_sphere | ninf)[0]
+    dual_sphere = dual_sphere / (-dual_sphere | ninf)[()]
     return math.sqrt(abs(dual_sphere * dual_sphere))
 
 
@@ -1012,7 +1012,7 @@ def point_pair_to_end_points(T):
 
 def euc_dist(conf_mv_a, conf_mv_b):
     """ Returns the distance between two conformal points """
-    dot_result = (conf_mv_a|conf_mv_b)[0]
+    dot_result = (conf_mv_a|conf_mv_b)[()]
     if dot_result < 0.0:
         return math.sqrt(-2.0*dot_result)
     else:
@@ -1374,26 +1374,26 @@ def calculate_S_over_mu(X1, X2):
     For any two conformal objects X1 and X2 this returns a factor that corrects
     the X1 + X2 back to a blade
     """
-    gamma1 = (X1 * X1)[0]
-    gamma2 = (X2 * X2)[0]
+    gamma1 = (X1 * X1)[()]
+    gamma2 = (X2 * X2)[()]
 
     M12 = X1 * X2 + X2 * X1
     K = 2 + gamma1 * M12
-    mu = (K[0]**2 - K(4)**2)[0]
+    mu = (K[()]**2 - K(4)**2)[()]
 
     if sum(np.abs(M12(4).value)) > 0.0000001:
-        lamb = (-(K(4) * K(4)))[0]
-        mu = K[0] ** 2 + lamb
+        lamb = (-(K(4) * K(4)))[()]
+        mu = K[()] ** 2 + lamb
         root_mu = np.sqrt(mu)
         if abs(lamb) < 0.0000001:
-            beta = 1.0 / (2 * np.sqrt(K[0]))
+            beta = 1.0 / (2 * np.sqrt(K[()]))
         else:
-            beta_sqrd = 1 / (2 * (root_mu + K[0]))
+            beta_sqrd = 1 / (2 * (root_mu + K[()]))
             beta = np.sqrt(beta_sqrd)
         S = -gamma1/(2*beta) + beta*M12(4)
         return S/np.sqrt(mu)
     else:
-        S = np.sqrt(abs(K[0]))
+        S = np.sqrt(abs(K[()]))
     return S/np.sqrt(mu)
 
 

--- a/clifford/tools/g3c/cost_functions.py
+++ b/clifford/tools/g3c/cost_functions.py
@@ -28,7 +28,7 @@ def check_p_cost(P, Q):
     """
     For leo dorsts check product cost
     """
-    return (P|check_p(Q))[0]
+    return (P|check_p(Q))[()]
 
 
 def point_to_line_cluster_distance(point, line_cluster):
@@ -134,7 +134,7 @@ def midline_and_error_of_plane_cluster(plane_cluster):
     ref_line = line_list[0]
     line_sum = 0.0 * e1
     for l in line_list:
-        if (ref_line | l)[0] > 0:
+        if (ref_line | l)[()] > 0:
             line_sum += l
         else:
             line_sum -= l
@@ -190,7 +190,7 @@ def alt_rotor_cost(V):
     scale_cost = np.abs(-2*logV[e45])
     scalefac = np.e**(-2*logV[e45])
     R = logV(e123)*e123
-    rotation_cost = abs((R*~R)[0])
+    rotation_cost = abs((R*~R)[()])
     translation_cost = scalefac*abs((logV - logV[e45]*e45 - logV(e123))|eo)
     return rotation_cost + scale_cost + translation_cost
 

--- a/clifford/tools/g3c/rotor_estimation.py
+++ b/clifford/tools/g3c/rotor_estimation.py
@@ -104,12 +104,12 @@ def lambda_estimate(Y_point_list, X_point_list, n_samples=50):
         i = indices[0]
         j = indices[1]
         k = indices[2]
-        lambdai2 = (X_point_list[i]|X_point_list[j])[0]
-        lambdai2 *= (X_point_list[i]|X_point_list[k])[0]
-        lambdai2 *= (Y_point_list[j]|Y_point_list[k])[0]
-        denom = (Y_point_list[i]|Y_point_list[j])[0]
-        denom *= (Y_point_list[i]|Y_point_list[k])[0]
-        denom *= (X_point_list[j]|X_point_list[k])[0]
+        lambdai2 = (X_point_list[i]|X_point_list[j])[()]
+        lambdai2 *= (X_point_list[i]|X_point_list[k])[()]
+        lambdai2 *= (Y_point_list[j]|Y_point_list[k])[()]
+        denom = (Y_point_list[i]|Y_point_list[j])[()]
+        denom *= (Y_point_list[i]|Y_point_list[k])[()]
+        denom *= (X_point_list[j]|X_point_list[k])[()]
         lamb2est += lambdai2/denom
     return np.sqrt(lamb2est/n_samples)
 

--- a/clifford/tools/g3c/rotor_parameterisation.py
+++ b/clifford/tools/g3c/rotor_parameterisation.py
@@ -23,7 +23,7 @@ def dorst_sinh(A):
     sinh of a bivector as given in square root and logarithm of rotors
     by Dorst and Valkenburg
     """
-    A2 = (A * A)[0]
+    A2 = (A * A)[()]
     if A2 > 0:
         root_A2 = np.sqrt(A2)
         return (np.sinh(root_A2) / root_A2) * A
@@ -38,7 +38,7 @@ def dorst_atanh2(s, c):
     """
     Atanh2 of a bivector as given in :cite:`log-of-rotors`
     """
-    s2 = (s * s)[0]
+    s2 = (s * s)[()]
     if s2 > 0:
         root_s2 = np.sqrt(s2)
         return (np.arcsinh(root_s2) / root_s2) * s
@@ -60,8 +60,8 @@ def decompose_bivector(F):
     if F2 == 0:
         return +F, 0*e1
     c2 = 0.5 * F2(4)
-    c1_2 = (c1 * c1)[0]
-    c2_2 = (c2 * c2)[0]
+    c1_2 = (c1 * c1)[()]
+    c2_2 = (c2 * c2)[()]
     lambs = np.roots([1, -c1_2, c2_2])
     F1 = (c1 * c2 - lambs[0] * c1) / (lambs[1] - lambs[0])
     F2 = (c1 * c2 - lambs[1] * c1) / (lambs[0] - lambs[1])
@@ -74,15 +74,15 @@ def general_logarithm(R):
 
     From :cite:`log-of-rotors`.
     """
-    F = 2 * (R(4) - R[0]) * R(2)
+    F = 2 * (R(4) - R[()]) * R(2)
     S1, S2 = decompose_bivector(F)
 
     def dorst_cosh(S):
-        s2 = (S * S)[0]
+        s2 = (S * S)[()]
         if abs(s2) < 0.000001:
-            return (R ** 2)[0]
+            return (R ** 2)[()]
         else:
-            return -((R ** 2)(2) * (S / s2))[0]
+            return -((R ** 2)(2) * (S / s2))[()]
 
     C1 = dorst_cosh(S2)
     C2 = dorst_cosh(S1)
@@ -226,7 +226,7 @@ def extractRotorComponents(R):
 
     From :cite:`wareham-interpolation`.
     """
-    phi = np.arccos(float(R[0]))             # scalar
+    phi = np.arccos(R[()])             # scalar
     phi2 = phi * phi                  # scalar
     # Notice: np.sinc(pi * x)/(pi x)
     phi_sinc = np.sinc(phi/np.pi)             # scalar


### PR DESCRIPTION
Addresses gh-344, gh-345.

In my opinion it is wrong to say that a multivector _is_ a sequence of coefficients - it happens to _have_ a sequence of coefficients, and if you want to access these you get all the sequence behavior through `.value`.


Let's see how many warnings our tests suite produces.