### PR TITLE
numba: Fix pickling

### DIFF
--- a/clifford/numba/_layout.py
+++ b/clifford/numba/_layout.py
@@ -32,6 +32,13 @@ class LayoutType(types.Dummy):
             name = "LayoutType({!r})".format(layout)
         super().__init__(name)
 
+    def __getstate__(self):
+        # the cache causes issues with numba's pickle modifications, as it
+        # contains a self-reference.
+        d = self.__dict__.copy()
+        d['_cache'] = {}
+        return d
+
 
 @numba.extending.register_model(LayoutType)
 class LayoutModel(numba.extending.models.OpaqueModel):

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -1,9 +1,11 @@
-import numba
 import operator
+import pickle
+
+import numba
+import pytest
 
 from clifford.g3c import layout, e1, e2, e3, e4, e5
 import clifford as cf
-import pytest
 
 
 @numba.njit
@@ -160,3 +162,13 @@ class TestOperators:
 
         assert func(a, 0, 1) == 1 + e1
         assert func(a, 0, 1, 2, 3, 4, 5) == a
+
+
+def test_pickling():
+    lt = layout._numba_type_
+    assert pickle.loads(pickle.dumps(lt)) is lt
+
+    # gh-349, populating `lt._cache` should not break pickling
+    e1._numba_type_  # int
+    (e1 * 1.0)._numba_type_  # float
+    assert pickle.loads(pickle.dumps(lt)) is lt


### PR DESCRIPTION
Fixes #349, by not saving the cache.

Objects that are round-tripped through pickle probably still have issues, but this at least prevents it crashing immediately.