### PR TITLE
Add missing citations to notebooks

### DIFF
--- a/clifford/tools/g3c/__init__.py
+++ b/clifford/tools/g3c/__init__.py
@@ -899,8 +899,9 @@ def meet_val(a_val, b_val):
 @numba.njit
 def meet(A, B):
     """
-    The meet algorithm as described in "A Covariant Approach to Geometry"
-    I5*((I5*A) ^ (I5*B))
+    The meet algorithm as described in :cite:`lasenby-covariant-approach`.
+
+    ``I5*((I5*A) ^ (I5*B))``
     """
     return fast_dual(fast_dual(A) ^ fast_dual(B))
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -75,3 +75,23 @@
     month = {Oct},
     pages = {375–389}
 }
+
+@techreport{lasenby-covariant-approach,
+    title = {A {Covariant} {Approach} to {Geometry} using {Geometric} {Algebra}},
+    abstract = {This report aims to show that using the mathematical framework of conformal geometric algebra – a 5-dimensional representation of 3-dimensional space – we are able to provide an elegant covariant approach to geometry. In this language, objects such as spheres, circles, lines and planes are simply elements of the algebra and can be transformed and intersected with ease. In addition, rotations, translation, dilations and inversions all become rotations in our 5-dimensional space; we will show how this enables us to provide very simple proofs of complicated constructions. We give examples of the use of this system in computer graphics and indicate how it can be extended into an even more powerful tool – we also discuss its advantages and disadvantages as a programming language. Lastly, we indicate how the framework might possibly be used to unify all geometries, thus enabling us to deal simply with the projective and non-Euclidean cases.},
+    language = {en},
+    author = {Lasenby, Anthony and Lasenby, Joan and Wareham, Rich},
+    year = {2004},
+    pages = {90},
+    url = {https://pdfs.semanticscholar.org/baba/976fd7f6577eeaa1d3ef488c1db13ec24652.pdf},
+    number = {F-INFENG/TR-483},
+    institution = {Department of Engineering, University of Cambridge},
+}
+
+@book{doran-ga4ph,
+    title = {Geometric {Algebra} for {Physicists}},
+    publisher = {Cambridge University Press},
+    author = {Doran, Chris and Lasenby, Anthony},
+    year = {2003},
+    url = {http://www.mrao.cam.ac.uk/~clifford}
+}

--- a/docs/tutorials/apollonius-cga-augmented.ipynb
+++ b/docs/tutorials/apollonius-cga-augmented.ipynb
@@ -217,7 +217,7 @@
    "metadata": {},
    "source": [
     "We hypothesize that this object is of the form `l2.ups(c4) ^ l2.ups(c5)`.\n",
-    "Taking a step not mentioned in the original paper, we decide to treat this as a regular conformal point pair, which allows us to project out the two factors with the approach taken in [A Covariant Approach to Geometry using Geometric Algebra](https://pdfs.semanticscholar.org/baba/976fd7f6577eeaa1d3ef488c1db13ec24652.pdf).\n",
+    "Taking a step not mentioned in the original paper, we decide to treat this as a regular conformal point pair, which allows us to project out the two factors with the approach taken in <cite data-cite=\"lasenby-covariant-approach\">A Covariant Approach to Geometry using Geometric Algebra</cite>.\n",
     "Here, we normalize with $e_{n+1}$ instead of the usual $n_\\infty$:"
    ]
   },

--- a/docs/tutorials/euler-angles.ipynb
+++ b/docs/tutorials/euler-angles.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "Following Sec. 2.7.5  from \"Geometric Algebra for Physicists\", we first rotate an angle $\\phi$ about the\n",
+    "Following Sec. 2.7.5  from <cite data-cite=\"doran-ga4ph\">Geometric Algebra for Physicists</cite>, we first rotate an angle $\\phi$ about the\n",
     "$e_3$-axis,  which is equivalent to rotating in the $e_{12}$-plane. This is done with the rotor\n",
     "\n",
     "$$ R_{\\phi} = e^{-\\frac{\\phi}{2} e_{12}}$$\n",

--- a/docs/tutorials/linear-transformations.ipynb
+++ b/docs/tutorials/linear-transformations.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "While geometric algebra already provides the rotors as a means of describing transformations (see [the CGA tutorial section](cga/index.ipynb#Operations)), there are types of linear transformation that are not suitable for this representation.\n",
     "\n",
-    "This tutorial leans heavily on the explanation of linear transformations in GA4CS, chapter 4. It explores the [clifford.transformations](../api/transformations.rst) submodule."
+    "This tutorial leans heavily on the explanation of linear transformations in <cite data-cite=\"ga4cs\">GA4CS</cite>, chapter 4. It explores the [clifford.transformations](../api/transformations.rst) submodule."
    ]
   },
   {


### PR DESCRIPTION
Let's see if this renders correctly:

* https://clifford--352.org.readthedocs.build/en/352/tutorials/apollonius-cga-augmented.html
* https://clifford--352.org.readthedocs.build/en/352/tutorials/euler-angles.html
* https://clifford--352.org.readthedocs.build/en/352/tutorials/linear-transformations.html