### PR TITLE
Preserve dtypes in left_complement, right_complement, and dual

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -574,7 +574,7 @@ class Layout(object):
 
         @_numba_utils.njit
         def comp_func(Xval):
-            Yval = np.zeros(dims)
+            Yval = np.zeros(dims, dtype=Xval.dtype)
             for i, s in enumerate(signlist):
                 Yval[i] = Xval[dims-1-i]*s
             return Yval

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -447,10 +447,14 @@ class Layout(object):
         else:
             # Equivalent to but faster than
             #   Iinv = self.pseudoScalar.inv().value
-            Iinv = np.zeros(self.gaDims)
             II_scalar = self.gmt[-1, 0, -1]
+            inv_II_scalar = 1 / II_scalar
+            if II_scalar in (1, -1):
+                Iinv = np.zeros(self.gaDims, dtype=int)
+            else:
+                Iinv = np.zeros(self.gaDims, dtype=type(inv_II_scalar))
             # set the pseudo-scalar part
-            Iinv[-1] = 1 / II_scalar
+            Iinv[-1] = inv_II_scalar
 
             gmt_func = self.gmt_func
             @_numba_utils.njit

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -379,6 +379,7 @@ class TestClifford:
         e1 = blades['e1'].astype(dtype)
         e2 = blades['e2'].astype(dtype)
         assert func(e1, np.int8(1)).value.dtype == dtype
+        assert func(np.int8(1), e1).value.dtype == dtype
         assert func(e1, e2).value.dtype == dtype
 
     @pytest.mark.parametrize('func', [

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -386,6 +386,8 @@ class TestClifford:
         operator.pos,
         operator.neg,
         MultiVector.gradeInvol,
+        MultiVector.right_complement,
+        MultiVector.left_complement,
     ])
     def test_unary_op_preserves_dtype(self, func, g3):
         """ test that simple unary ops on blades do not promote types """

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -386,6 +386,7 @@ class TestClifford:
         operator.pos,
         operator.neg,
         MultiVector.gradeInvol,
+        MultiVector.dual,
         MultiVector.right_complement,
         MultiVector.left_complement,
     ])

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,9 @@ Changes in 1.4.x
  * Projection using :meth:`Multivector.__call__` no longer raises :exc:`ValueError`
    for grades not present in the algebra, and instead just returns zero.
 
+ * Where possible, ``MultiVector``\ s preserve their data type in the dual, and
+   the right and left complements.
+
 Changes in 1.3.x
 ++++++++++++++++
 


### PR DESCRIPTION
Split from #355