### PR TITLE
Speed up imports

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -560,8 +560,9 @@ class Layout(object):
 
         # Since we're working with basis blades, we can use the table directly.
         # We only care about the pseudo-scalar part of the wedge.
+        omt_ps_part = omt[:, -1, :]
         for n in range(dims):
-            signlist[n] = (-1)**(omt[n, -1, dims-1-n] < 0.001)
+            signlist[n] = (-1)**(omt_ps_part[n, dims-1-n] < 0.001)
 
         @_numba_utils.njit
         def comp_func(Xval):

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -353,18 +353,6 @@ class Layout(object):
                 "names list of length %i needs to be of length %i" %
                 (len(names), self.gaDims))
 
-        # preload these lazy properties. Not doing this would likely be faster.
-        self.gmt_func
-        self.imt_func
-        self.omt_func
-        self.lcmt_func
-        self.adjoint_func
-        self.left_complement_func
-        self.right_complement_func
-        self.dual_func
-        self.vee_func
-        self.inv_func
-
     @property
     def gradeList(self):
         return list(self._basis_blade_order.grades)

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -95,7 +95,7 @@ def lcmt_check(grade_v, grade_i, grade_j):
     return grade_v == (grade_j - grade_i)
 
 
-@_numba_utils.njit(parallel=NUMBA_PARALLEL, nogil=True)
+@_numba_utils.njit(parallel=NUMBA_PARALLEL, nogil=True, cache=True)
 def _numba_construct_gmt(
     index_to_bitmap, bitmap_to_index, signature
 ):

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -39,7 +39,7 @@ class _cached_property:
         return val
 
 
-@_numba_utils.njit
+@_numba_utils.njit(cache=True)
 def canonical_reordering_sign(bitmap_a, bitmap_b, metric):
     """
     Computes the sign for the product of bitmap_a and bitmap_b
@@ -56,7 +56,7 @@ def canonical_reordering_sign(bitmap_a, bitmap_b, metric):
     return output_sign
 
 
-@_numba_utils.njit
+@_numba_utils.njit(cache=True)
 def gmt_element(bitmap_a, bitmap_b, sig_array):
     """
     Element of the geometric multiplication table given blades a, b.
@@ -67,7 +67,7 @@ def gmt_element(bitmap_a, bitmap_b, sig_array):
     return output_bitmap, output_sign
 
 
-@_numba_utils.njit
+@_numba_utils.njit(cache=True)
 def imt_check(grade_v, grade_i, grade_j):
     """
     A check used in imt table generation
@@ -77,7 +77,7 @@ def imt_check(grade_v, grade_i, grade_j):
     return (grade_v == abs(grade_i - grade_j)) and (grade_i != 0) and (grade_j != 0)
 
 
-@_numba_utils.njit
+@_numba_utils.njit(cache=True)
 def omt_check(grade_v, grade_i, grade_j):
     """
     A check used in omt table generation
@@ -86,7 +86,7 @@ def omt_check(grade_v, grade_i, grade_j):
     return grade_v == (grade_i + grade_j)
 
 
-@_numba_utils.njit
+@_numba_utils.njit(cache=True)
 def lcmt_check(grade_v, grade_i, grade_j):
     """
     A check used in lcmt table generation

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -560,9 +560,8 @@ class Layout(object):
 
         # Since we're working with basis blades, we can use the table directly.
         # We only care about the pseudo-scalar part of the wedge.
-        omt_ps_part = omt[:, -1, :]
         for n in range(dims):
-            signlist[n] = (-1)**(omt_ps_part[n, dims-1-n] < 0.001)
+            signlist[n] = (-1)**(omt[n, -1, dims-1-n] < 0.001)
 
         @_numba_utils.njit
         def comp_func(Xval):

--- a/clifford/test/test_algebra_initialisation.py
+++ b/clifford/test/test_algebra_initialisation.py
@@ -20,7 +20,7 @@ class TestInitialisation:
     ])
     def test_speed(self, n, benchmark):
         def generate_algebra():
-            layout = Cl(n)
+            layout = Cl(n)[0]
             layout.gmt_func
             layout.imt_func
             layout.omt_func

--- a/clifford/test/test_algebra_initialisation.py
+++ b/clifford/test/test_algebra_initialisation.py
@@ -19,7 +19,19 @@ class TestInitialisation:
         for x in range(7, 9)
     ])
     def test_speed(self, n, benchmark):
-        benchmark(Cl, n)
+        def generate_algebra():
+            layout = Cl(n)
+            layout.gmt_func
+            layout.imt_func
+            layout.omt_func
+            layout.lcmt_func
+            layout.adjoint_func
+            layout.left_complement_func
+            layout.right_complement_func
+            layout.dual_func
+            layout.vee_func
+            layout.inv_func
+        benchmark(generate_algebra)
 
     @too_slow_without_jit
     @pytest.mark.veryslow


### PR DESCRIPTION
Speed up imports (especially of conformal algebras) by removing the function preloading and adding some minor caching where possible