### PR TITLE
Do not coerce 0d MVArrays into 1d arrays

### DIFF
--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -60,8 +60,8 @@ class MultiVector(object):
                     self.layout.gaDims)
 
     def __array__(self) -> 'cf.MVArray':
-        # we are a scalar, and the only appropriate dtype is an object array
-        return cf.MVArray([self])
+        # ensure that coercion gives our array subclass
+        return cf.array(self)
 
     def _checkOther(self, other, coerce=True) -> Tuple['MultiVector', bool]:
         """Ensure that the other argument has the same Layout or coerce value if

--- a/clifford/_mvarray.py
+++ b/clifford/_mvarray.py
@@ -139,6 +139,9 @@ def array(obj):
     '''
     an array method like :func:`numpy.array`, but returns a :class:`.MVArray`.
 
+    .. versionchanged:: 1.4
+        Now produces 0d arrays when ``obj`` is a single :class:`MultiVector`
+
     Parameters
     -------------
     obj : MultiVector, list
@@ -152,8 +155,4 @@ def array(obj):
     >>> np.array([1, 2, 3])*cf.array(g3.e12)
     MVArray([(1^e12), (2^e12), (3^e12)], dtype=object)
     '''
-    if isinstance(obj, MultiVector):
-        # they passed a single MV so make a list of it.
-        return MVArray([obj])
-    else:
-        return MVArray(obj)
+    return MVArray(obj)

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -137,7 +137,7 @@ class TestClifford:
 
         B = layout.MultiVector(valB)
         expB = layout.MultiVector(valexpB)
-        np.testing.assert_almost_equal(np.exp(B)[0].value, expB.value)
+        np.testing.assert_almost_equal(np.exp(B).value, expB.value)
 
     def test_inv_g4(self, g4):
         '''
@@ -248,6 +248,20 @@ class TestClifford:
             for j in range(Ncolumns):
                 value_array_ip[i, j, :] = layout.imt_func(value_array_a[i, j, :], value_array_b[i, j, :])
         np.testing.assert_array_equal(mv_array_ip.value, value_array_ip)
+
+    def test_array_0d(self, g3):
+        layout, blades = g3, g3.blades
+        e1 = blades['e1']
+
+        arr = np.asanyarray(e1)
+        assert isinstance(arr, MVArray)
+        assert arr.shape == ()
+        assert arr[()] is e1
+
+        arr = clifford.array(e1)
+        assert isinstance(arr, MVArray)
+        assert arr.shape == ()
+        assert arr[()] is e1
 
     def test_array_control(self, g3):
         '''


### PR DESCRIPTION
If a user asks for a 0d array, they should get a 0d array.