### PR TITLE
Use C-order arrays where possible in numba extension types

### DIFF
--- a/clifford/numba/_layout.py
+++ b/clifford/numba/_layout.py
@@ -25,7 +25,6 @@ class LayoutType(types.Dummy):
         self.obj = layout
         # cache of multivector types for this layout
         self._c_cache = {}
-        self._f_cache = {}
         self._a_cache = {}
         layout_name = layout_short_name(layout)
         if layout_name is not None:
@@ -39,7 +38,6 @@ class LayoutType(types.Dummy):
         # contains a self-reference.
         d = self.__dict__.copy()
         d['_c_cache'] = {}
-        d['_f_cache'] = {}
         d['_a_cache'] = {}
         return d
 

--- a/clifford/numba/_layout.py
+++ b/clifford/numba/_layout.py
@@ -23,7 +23,9 @@ from .._multivector import MultiVector
 class LayoutType(types.Dummy):
     def __init__(self, layout):
         self.obj = layout
-        # cache of multivector types for this layout
+        # Caches of multivector types for this layout, in numba C and A order.
+        # Having two caches is faster than a cache keyed by a tuple of `(order, dt)`,
+        # and every millisecond counts in `MultiVector._numba_type_`.
         self._c_cache = {}
         self._a_cache = {}
         layout_name = layout_short_name(layout)

--- a/clifford/numba/_layout.py
+++ b/clifford/numba/_layout.py
@@ -24,7 +24,9 @@ class LayoutType(types.Dummy):
     def __init__(self, layout):
         self.obj = layout
         # cache of multivector types for this layout
-        self._cache = {}
+        self._c_cache = {}
+        self._f_cache = {}
+        self._a_cache = {}
         layout_name = layout_short_name(layout)
         if layout_name is not None:
             name = "LayoutType({})".format(layout_name)
@@ -36,7 +38,9 @@ class LayoutType(types.Dummy):
         # the cache causes issues with numba's pickle modifications, as it
         # contains a self-reference.
         d = self.__dict__.copy()
-        d['_cache'] = {}
+        d['_c_cache'] = {}
+        d['_f_cache'] = {}
+        d['_a_cache'] = {}
         return d
 
 

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -14,13 +14,11 @@ try:
     import numba.np.numpy_support as _numpy_support
     from numba.core.imputils import impl_ret_borrowed, lower_constant
     from numba.core import cgutils, types
-    from numba.core.typing.typeof import typeof_impl
 except ImportError:
     # module locations prior to numba 0.49.0
     import numba.numpy_support as _numpy_support
     from numba.targets.imputils import impl_ret_borrowed, lower_constant
     from numba import cgutils, types
-    from numba.typing.typeof import typeof_impl
 
 from .._multivector import MultiVector
 
@@ -28,7 +26,6 @@ from ._layout import LayoutType
 from ._overload_call import overload_call
 
 __all__ = ['MultiVectorType']
-_typeof_ndarray = typeof_impl.dispatch(np.ndarray)
 
 
 class MultiVectorType(types.Type):

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -34,7 +34,7 @@ _typeof_ndarray = typeof_impl.dispatch(np.ndarray)
 class MultiVectorType(types.Type):
     def __init__(self, layout: LayoutType, dtype: types.DType):
         self.layout_type = layout
-        self._array_type = dtype
+        self.value_type = dtype
         super().__init__(name='MultiVector({!r}, {!r})'.format(
             self.layout_type, self._array_type
         ))
@@ -42,10 +42,6 @@ class MultiVectorType(types.Type):
     @property
     def key(self):
         return self.layout_type, self._array_type
-
-    @property
-    def value_type(self):
-        return self._array_type
 
 
 # The docs say we should use register a function to determine the numba type

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -54,6 +54,9 @@ def _numba_type_(self):
     cache = layout_type._cache
     dt = self.value.dtype
 
+    if not self.value.flags.c_contiguous:
+        raise ValueError('Clifford currently only supports JITing functions of MultiVectors with C_CONTIGUOUS value arrays.')
+
     # now use the dtype to key that cache.
     try:
         return cache[dt]

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -56,16 +56,15 @@ def _numba_type_(self):
 
     cache = layout_type._cache
     dt = self.value.dtype
-    C_contig = self.value.flags.C_CONTIGUOUS
 
     # now use the dtype to key that cache.
     try:
-        return cache[(dt, C_contig)]
+        return cache[dt]
     except KeyError:
         # Computing and hashing `dtype_type` is slow, so we do not use it as a
         # hash key. The raw numpy dtype is much faster to use as a key.
         dtype_type = _typeof_ndarray(self.value, None)
-        ret = cache[(dt, C_contig)] = MultiVectorType(layout_type, dtype_type)
+        ret = cache[dt] = MultiVectorType(layout_type, dtype_type)
         return ret
 
 MultiVector._numba_type_ = _numba_type_

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -36,12 +36,12 @@ class MultiVectorType(types.Type):
         self.layout_type = layout
         self.value_type = dtype
         super().__init__(name='MultiVector({!r}, {!r})'.format(
-            self.layout_type, self._array_type
+            self.layout_type, self.value_type
         ))
 
     @property
     def key(self):
-        return self.layout_type, self._array_type
+        return self.layout_type, self.value_type
 
 
 # The docs say we should use register a function to determine the numba type

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -55,10 +55,10 @@ def _numba_type_(self):
 
     layout_type = self.layout._numba_type_
 
-    relevant_cache = layout_type._c_cache
     dt = self.value.dtype
-
-    if not self.value.flags.c_contiguous:
+    if self.value.flags.c_contiguous:
+        relevant_cache = layout_type._c_cache
+    else:
         relevant_cache = layout_type._a_cache
 
     # now use the dtype to key that cache.

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -55,7 +55,7 @@ def _numba_type_(self):
     dt = self.value.dtype
 
     if not self.value.flags.c_contiguous:
-        raise ValueError('Clifford currently only supports JITing functions of MultiVectors with C_CONTIGUOUS value arrays.')
+        raise ValueError("Only clifford.MultiVector objects with contiguous coefficients can be passed to JITted functions")
 
     # now use the dtype to key that cache.
     try:

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -61,10 +61,10 @@ def _numba_type_(self):
     try:
         return cache[dt]
     except KeyError:
-        # Computing and hashing `dtype_type` is slow, so we do not use it as a
+        # Computing and hashing `value_type` is slow, so we do not use it as a
         # hash key. The raw numpy dtype is much faster to use as a key.
-        dtype_type = _numpy_support.from_dtype(dt)[::1]  # c-order
-        ret = cache[dt] = MultiVectorType(layout_type, dtype_type)
+        value_type = _typeof_ndarray(self.value, None)
+        ret = cache[dt] = MultiVectorType(layout_type, value_type)
         return ret
 
 MultiVector._numba_type_ = _numba_type_

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -56,15 +56,16 @@ def _numba_type_(self):
 
     cache = layout_type._cache
     dt = self.value.dtype
+    C_contig = self.value.flags.C_CONTIGUOUS
 
     # now use the dtype to key that cache.
     try:
-        return cache[dt]
+        return cache[(dt, C_contig)]
     except KeyError:
         # Computing and hashing `dtype_type` is slow, so we do not use it as a
         # hash key. The raw numpy dtype is much faster to use as a key.
         dtype_type = _typeof_ndarray(self.value, None)
-        ret = cache[dt] = MultiVectorType(layout_type, dtype_type)
+        ret = cache[(dt, C_contig)] = MultiVectorType(layout_type, dtype_type)
         return ret
 
 MultiVector._numba_type_ = _numba_type_

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -63,7 +63,7 @@ def _numba_type_(self):
     except KeyError:
         # Computing and hashing `value_type` is slow, so we do not use it as a
         # hash key. The raw numpy dtype is much faster to use as a key.
-        value_type = _typeof_ndarray(self.value, None)
+        value_type = _numpy_support.from_dtype(dt)[::1]  # c-order
         ret = cache[dt] = MultiVectorType(layout_type, value_type)
         return ret
 

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -153,7 +153,7 @@ def ga_add(a, b):
         return impl
     elif isinstance(a, types.abstract.Number) and isinstance(b, MultiVectorType):
         scalar_index = b.layout_type.obj._basis_blade_order.bitmap_to_index[0]
-        ret_type = np.result_type(_numpy_support.as_dtype(a), _numpy_support.as_dtype(b.value_type.dtype))
+        ret_type = np.result_type(_numpy_support.as_dtype(a), b.value_type)
         def impl(a, b):
             op = b.value.astype(ret_type)
             op[scalar_index] += a
@@ -161,7 +161,7 @@ def ga_add(a, b):
         return impl
     elif isinstance(a, MultiVectorType) and isinstance(b, types.abstract.Number):
         scalar_index = a.layout_type.obj._basis_blade_order.bitmap_to_index[0]
-        ret_type = np.result_type(_numpy_support.as_dtype(a.value_type.dtype), _numpy_support.as_dtype(b))
+        ret_type = np.result_type(a.value_type, _numpy_support.as_dtype(b))
         def impl(a, b):
             op = a.value.astype(ret_type)
             op[scalar_index] += b
@@ -179,7 +179,7 @@ def ga_sub(a, b):
         return impl
     elif isinstance(a, types.abstract.Number) and isinstance(b, MultiVectorType):
         scalar_index = b.layout_type.obj._basis_blade_order.bitmap_to_index[0]
-        ret_type = np.result_type(_numpy_support.as_dtype(a), _numpy_support.as_dtype(b.value_type.dtype))
+        ret_type = np.result_type(_numpy_support.as_dtype(a), b.value_type)
         def impl(a, b):
             op = -b.value.astype(ret_type)
             op[scalar_index] += a
@@ -187,7 +187,7 @@ def ga_sub(a, b):
         return impl
     elif isinstance(a, MultiVectorType) and isinstance(b, types.abstract.Number):
         scalar_index = a.layout_type.obj._basis_blade_order.bitmap_to_index[0]
-        ret_type = np.result_type(_numpy_support.as_dtype(a.value_type.dtype), _numpy_support.as_dtype(b))
+        ret_type = np.result_type(a.value_type, _numpy_support.as_dtype(b))
         def impl(a, b):
             op = a.value.astype(ret_type)
             op[scalar_index] -= b
@@ -242,12 +242,12 @@ def ga_or(a, b):
             return a.layout.MultiVector(imt_func(a.value, b.value))
         return impl
     elif isinstance(a, types.abstract.Number) and isinstance(b, MultiVectorType):
-        ret_type = np.result_type(_numpy_support.as_dtype(a), _numpy_support.as_dtype(b.value_type.dtype))
+        ret_type = np.result_type(_numpy_support.as_dtype(a), b.value_type)
         def impl(a, b):
             return b.layout.MultiVector(np.zeros_like(b.value, dtype=ret_type))
         return impl
     elif isinstance(a, MultiVectorType) and isinstance(b, types.abstract.Number):
-        ret_type = np.result_type(_numpy_support.as_dtype(a.value_type.dtype), _numpy_support.as_dtype(b))
+        ret_type = np.result_type(a.value_type, _numpy_support.as_dtype(b))
         def impl(a, b):
             return a.layout.MultiVector(np.zeros_like(a.value, dtype=ret_type))
         return impl

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -68,7 +68,7 @@ def _numba_type_(self):
     except KeyError:
         # Computing and hashing `value_type` is slow, so we do not use it as a
         # hash key. The raw numpy dtype is much faster to use as a key.
-        value_type = _numpy_support.from_dtype(dt)[::1]  # c-order
+        value_type = _numpy_support.from_dtype(dt)[:]
         ret = relevant_cache[dt] = MultiVectorType(layout_type, value_type)
         return ret
 

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -88,7 +88,7 @@ class MultiVectorModel(numba.extending.models.StructModel):
 def type_MultiVector(context):
     def typer(layout, value):
         if isinstance(layout, LayoutType) and isinstance(value, types.Array):
-            return MultiVectorType(layout, _typeof_ndarray(value, None))
+            return MultiVectorType(layout, value)
     return typer
 
 

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -63,7 +63,7 @@ def _numba_type_(self):
     except KeyError:
         # Computing and hashing `dtype_type` is slow, so we do not use it as a
         # hash key. The raw numpy dtype is much faster to use as a key.
-        dtype_type = _typeof_ndarray(self.value, None)
+        dtype_type = _numpy_support.from_dtype(dt)[::1]  # c-order
         ret = cache[dt] = MultiVectorType(layout_type, dtype_type)
         return ret
 

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -153,7 +153,7 @@ def ga_add(a, b):
         return impl
     elif isinstance(a, types.abstract.Number) and isinstance(b, MultiVectorType):
         scalar_index = b.layout_type.obj._basis_blade_order.bitmap_to_index[0]
-        ret_type = np.result_type(_numpy_support.as_dtype(a), b.value_type)
+        ret_type = np.result_type(_numpy_support.as_dtype(a), _numpy_support.as_dtype(b.value_type.dtype))
         def impl(a, b):
             op = b.value.astype(ret_type)
             op[scalar_index] += a
@@ -161,7 +161,7 @@ def ga_add(a, b):
         return impl
     elif isinstance(a, MultiVectorType) and isinstance(b, types.abstract.Number):
         scalar_index = a.layout_type.obj._basis_blade_order.bitmap_to_index[0]
-        ret_type = np.result_type(a.value_type, _numpy_support.as_dtype(b))
+        ret_type = np.result_type(_numpy_support.as_dtype(a.value_type.dtype), _numpy_support.as_dtype(b))
         def impl(a, b):
             op = a.value.astype(ret_type)
             op[scalar_index] += b
@@ -179,7 +179,7 @@ def ga_sub(a, b):
         return impl
     elif isinstance(a, types.abstract.Number) and isinstance(b, MultiVectorType):
         scalar_index = b.layout_type.obj._basis_blade_order.bitmap_to_index[0]
-        ret_type = np.result_type(_numpy_support.as_dtype(a), b.value_type)
+        ret_type = np.result_type(_numpy_support.as_dtype(a), _numpy_support.as_dtype(b.value_type.dtype))
         def impl(a, b):
             op = -b.value.astype(ret_type)
             op[scalar_index] += a
@@ -187,7 +187,7 @@ def ga_sub(a, b):
         return impl
     elif isinstance(a, MultiVectorType) and isinstance(b, types.abstract.Number):
         scalar_index = a.layout_type.obj._basis_blade_order.bitmap_to_index[0]
-        ret_type = np.result_type(a.value_type, _numpy_support.as_dtype(b))
+        ret_type = np.result_type(_numpy_support.as_dtype(a.value_type.dtype), _numpy_support.as_dtype(b))
         def impl(a, b):
             op = a.value.astype(ret_type)
             op[scalar_index] -= b
@@ -242,12 +242,12 @@ def ga_or(a, b):
             return a.layout.MultiVector(imt_func(a.value, b.value))
         return impl
     elif isinstance(a, types.abstract.Number) and isinstance(b, MultiVectorType):
-        ret_type = np.result_type(_numpy_support.as_dtype(a), b.value_type)
+        ret_type = np.result_type(_numpy_support.as_dtype(a), _numpy_support.as_dtype(b.value_type.dtype))
         def impl(a, b):
             return b.layout.MultiVector(np.zeros_like(b.value, dtype=ret_type))
         return impl
     elif isinstance(a, MultiVectorType) and isinstance(b, types.abstract.Number):
-        ret_type = np.result_type(a.value_type, _numpy_support.as_dtype(b))
+        ret_type = np.result_type(_numpy_support.as_dtype(a.value_type.dtype), _numpy_support.as_dtype(b))
         def impl(a, b):
             return a.layout.MultiVector(np.zeros_like(a.value, dtype=ret_type))
         return impl

--- a/clifford/test/test_function_cache.py
+++ b/clifford/test/test_function_cache.py
@@ -8,7 +8,7 @@ warnings.simplefilter("error")
 
 @generated_jit(cache=True)
 def foo(x):
-    from clifford.g3c import e3
+    from clifford.g3 import e3
 
     def impl(x):
         return (x * e3).value

--- a/clifford/test/test_function_cache.py
+++ b/clifford/test/test_function_cache.py
@@ -1,9 +1,6 @@
 import numpy as np
 from numba import generated_jit
-import warnings
-
-# Make the test fail on a failed cache warning
-warnings.simplefilter("error")
+import pytest
 
 
 @generated_jit(cache=True)
@@ -15,6 +12,8 @@ def foo(x):
     return impl
 
 
+# Make the test fail on a failed cache warning
+@pytest.mark.filterwarnings("error")
 def test_function_cache():
-    from clifford.g3c import e3
+    from clifford.g3 import e3
     np.testing.assert_array_equal((1.0*e3).value, foo(1.0))

--- a/clifford/test/test_function_cache.py
+++ b/clifford/test/test_function_cache.py
@@ -1,0 +1,17 @@
+import numpy as np
+import numba
+from numba import generated_jit
+import warnings; warnings.simplefilter("error")
+
+
+@generated_jit(cache=True)
+def foo(x):
+    from clifford.g3c import e3
+    def impl(x):
+        return (x * e3).value
+    return impl
+
+
+def test_function_cache():
+	from clifford.g3c import e3
+	np.testing.assert_array_equal((1.0*e3).value, foo(1.0))

--- a/clifford/test/test_function_cache.py
+++ b/clifford/test/test_function_cache.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numba import generated_jit
+from clifford._numba_utils import generated_jit
 import pytest
 
 

--- a/clifford/test/test_function_cache.py
+++ b/clifford/test/test_function_cache.py
@@ -1,17 +1,20 @@
 import numpy as np
-import numba
 from numba import generated_jit
-import warnings; warnings.simplefilter("error")
+import warnings
+
+# Make the test fail on a failed cache warning
+warnings.simplefilter("error")
 
 
 @generated_jit(cache=True)
 def foo(x):
     from clifford.g3c import e3
+
     def impl(x):
         return (x * e3).value
     return impl
 
 
 def test_function_cache():
-	from clifford.g3c import e3
-	np.testing.assert_array_equal((1.0*e3).value, foo(1.0))
+    from clifford.g3c import e3
+    np.testing.assert_array_equal((1.0*e3).value, foo(1.0))

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -181,10 +181,11 @@ def test_A_order():
     def mul_mv(mv):
         return mv*e3
 
-    mva = layout.MultiVector(np.ones(8)[::-1])
+    mva = layout.MultiVector(np.ones(layout.gaDims))
+    mva.value = mva.value[::-1]
     assert not mva.value.c_contiguous
 
-    mvc = layout.MultiVector(np.ones(8, order='C'))
+    mvc = layout.MultiVector(np.ones(layout.gaDims))
     resa = mul_mv(mva)
     resc = mul_mv(mvc)
     assert resa == resc

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -181,14 +181,15 @@ def test_A_order():
     def mul_mv(mv):
         return mv*e3
 
+    # A-order
     mva = layout.MultiVector(np.ones(layout.gaDims))
     mva.value = mva.value[::-1]
     assert not mva.value.flags.c_contiguous
+    res_mva = mul_mv(mva)
 
+    # C-order
     mvc = layout.MultiVector(np.ones(layout.gaDims))
+    assert mvc.value.flags.c_contiguous
+    res_mvc = mul_mv(mvc)
 
-    with pytest.raises(ValueError):
-        mul_mv(mva)
-
-    # C-order is fine
-    mul_mv(mvc)
+    assert res_mva == res_mvc

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -174,15 +174,15 @@ def test_pickling():
     assert pickle.loads(pickle.dumps(lt)) is lt
 
 
-def test_F_order():
+def test_A_order():
     import numpy as np
 
     @numba.njit
-    def mul_mv(a):
-        return a*e3
+    def mul_mv(mv):
+        return mv*e3
 
-    mva = layout.MultiVector(np.ones(8, order='F'))
-    mvb = layout.MultiVector(np.ones(8, order='C'))
+    mva = layout.MultiVector(np.ones(8)[::-1])
+    mvc = layout.MultiVector(np.ones(8, order='C'))
     resa = mul_mv(mva)
-    resb = mul_mv(mvb)
-    assert resa == resb
+    resc = mul_mv(mvc)
+    assert resa == resc

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -183,7 +183,7 @@ def test_A_order():
 
     mva = layout.MultiVector(np.ones(layout.gaDims))
     mva.value = mva.value[::-1]
-    assert not mva.value.c_contiguous
+    assert not mva.value.flags.c_contiguous
 
     mvc = layout.MultiVector(np.ones(layout.gaDims))
     resa = mul_mv(mva)

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -182,6 +182,8 @@ def test_A_order():
         return mv*e3
 
     mva = layout.MultiVector(np.ones(8)[::-1])
+    assert not mva.value.c_contiguous
+
     mvc = layout.MultiVector(np.ones(8, order='C'))
     resa = mul_mv(mva)
     resc = mul_mv(mvc)

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -186,9 +186,9 @@ def test_A_order():
     assert not mva.value.flags.c_contiguous
 
     mvc = layout.MultiVector(np.ones(layout.gaDims))
-    
+
     with pytest.raises(ValueError):
         mul_mv(mva)
-    
+
     # C-order is fine
     mul_mv(mvc)

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -186,6 +186,9 @@ def test_A_order():
     assert not mva.value.flags.c_contiguous
 
     mvc = layout.MultiVector(np.ones(layout.gaDims))
-    resa = mul_mv(mva)
-    resc = mul_mv(mvc)
-    assert resa == resc
+    
+    with pytest.raises(ValueError):
+        mul_mv(mva)
+    
+    # C-order is fine
+    mul_mv(mvc)

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -172,3 +172,17 @@ def test_pickling():
     e1._numba_type_  # int
     (e1 * 1.0)._numba_type_  # float
     assert pickle.loads(pickle.dumps(lt)) is lt
+
+
+def test_F_order():
+    import numpy as np
+
+    @numba.njit
+    def mul_mv(a):
+        return a*e3
+
+    mva = layout.MultiVector(np.ones(8, order='F'))
+    mvb = layout.MultiVector(np.ones(8, order='C'))
+    resa = mul_mv(mva)
+    resb = mul_mv(mvb)
+    assert resa == resb


### PR DESCRIPTION
Hopefully solves https://github.com/pygae/clifford/issues/363, allowing multivector constants to be used in cached functions; as only C-order arrays are candidates for caching.

Previously only A-order arrays were supported.