### PR TITLE
Added a .pinv() method to MultiVectors plus tests

### DIFF
--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -773,6 +773,9 @@ class MultiVector(object):
     leftInv = leftLaInv
     rightInv = leftLaInv
 
+    def pinv(self) -> 'MultiVector':
+        return self._newMV(self.layout.pinv_func(self.value))
+
     def dual(self, I=None) -> 'MultiVector':
         r"""The dual of the multivector against the given subspace I, :math:`\tilde M = MI^{-1}`
 

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -184,6 +184,17 @@ class TestClifford:
             e12[1 + e12]
         assert e12[(2, 1)] == -1
 
+    def test_pinv(self, g3):
+        layout, blades = g3, g3.blades
+        e2 = blades['e2']
+        e3 = blades['e3']
+        x = 0.5*(1-e3)  # Singular
+        y = 2*e2 + 5*e3 # invertible
+        with pytest.raises(ValueError):
+            x.leftLaInv()
+        assert x == x.pinv()
+        assert y.pinv() == y.leftLaInv()
+
     def test_add_float64(self, g3):
         '''
         test array_wrap method to take control addition from numpy array


### PR DESCRIPTION
PR implementing #366. 

I've added a method `.pinv()` to multivectors, which returns the pseudoinverse instead of the normal inverse. Identical to the matrix inverse method but when invoked on singular elements this does not throw an error but instead returns the original element, because well... it's singular.