### PR TITLE
Documentation: Fix/add links to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Scalars, vectors, and higher-grade entities can be mixed freely and consistently
 ![Visual explanation of blades](https://raw.githubusercontent.com/pygae/clifford/master/docs/_static/blades.png)
 
 
+Quick Installation
+------------
+Requires Python version >=3.7
+
+Install using `conda`:
+```
+conda install clifford -c conda-forge
+```
+Install using `pip`:
+```
+pip3 install clifford
+```
+[Detailed instructions](https://slides.com/hugohadfield/installing-python-and-clifford)
+
 Quickstart
 ----------
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Scalars, vectors, and higher-grade entities can be mixed freely and consistently
 
 Quick Installation
 ------------
-Requires Python version >=3.7
+Requires Python version >=3.5
 
 Install using `conda`:
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Install using `pip`:
 ```
 pip3 install clifford
 ```
-[Detailed instructions](https://slides.com/hugohadfield/installing-python-and-clifford)
+[Detailed instructions](https://clifford.readthedocs.io/en/latest/installation.html)
 
 Quickstart
 ----------

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Scalars, vectors, and higher-grade entities can be mixed freely and consistently
 
 
 Quick Installation
-------------
+------------------
 Requires Python version >=3.5
 
 Install using `conda`:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ Scalars, vectors, and higher-grade entities can be mixed freely and consistently
     :maxdepth: 3
     :hidden:
 
-    Installation
+    installation
     api/index
     predefined-algebras
     changelog


### PR DESCRIPTION
I noticed there were no links to installation instructions on the published versions of
* `README.md`
* `docs/index.rst`
So, I added simple instructions to `README.md` plus a link to the documentation page, and fixed the broken link in the documentation index.