### PR TITLE
Pin sphinxcontrib-bibtex to <2.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ nbsphinx
 ipywidgets
 sphinx>=2.4
 sphinx_rtd_theme
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex<2.0.0
 
 # needed to avoid https://github.com/sphinx-doc/sphinx/issues/8198
 pygments>=2.4.1


### PR DESCRIPTION
This module is casuing our docs builds to fail, see for example:
https://readthedocs.org/projects/clifford/builds/12643876/

Here is the thread from which I grabbed this solution:
https://github.com/executablebooks/jupyter-book/issues/1137