### PR TITLE
Fix the docbuilds with sphinxcontrib-bibtex>=2.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,8 @@ extensions = [
     #'sphinx.ext.mathjax',
 ]
 
+bibtex_bibfiles = ['refs.bib']
+
 nbsphinx_execute = 'always'
 nbsphinx_allow_errors = True
 nbsphinx_kernel_name = 'python'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ nbsphinx
 ipywidgets
 sphinx>=2.4
 sphinx_rtd_theme>=0.5.0
-sphinxcontrib-bibtex<2.0.0
+sphinxcontrib-bibtex>=2.3.0
 
 # needed to avoid https://github.com/sphinx-doc/sphinx/issues/8198
 pygments>=2.4.1


### PR DESCRIPTION
The new version of sphinxcontrib-bibtex shows citation information in a tooltip:

![image](https://user-images.githubusercontent.com/425260/126302627-db2af42d-1b5a-4ba8-a672-679038b5e9dd.png)
