### PR TITLE
Fix a CI failure on Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ x-clifford-templates:
             IPython \
             h5py;
           conda install -c conda-forge sparse;
+          if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
+            # parso 0.8.0 does not work on 3.5
+            conda install -c conda-forge "parso<0.8.0"
+          fi
           conda install -c numba "numba>=0.45.1";
         else
           pip install IPython;


### PR DESCRIPTION
Parso is only used by our tests, as a transitive dependency of IPython

Here's a failing run: https://travis-ci.org/github/pygae/clifford/jobs/751695858#L2902