### PR TITLE
Fix RTD builds broken by the notebook header

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ nbsphinx_timeout = 60
 # This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = r"""
 {% set docname = 'docs/' + env.doc2path(env.docname, base=None) %}
-{% set git_ref = 'master' if '.' not in env.config.current_version else 'v' + env.config.release %}
+{% set git_ref = 'master' if not READTHEDOCS or '.' not in current_version else 'v' + env.config.release %}
 .. raw:: html
 
     <div class="admonition note">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ nbsphinx_timeout = 60
 # This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = r"""
 {% set docname = 'docs/' + env.doc2path(env.docname, base=None) %}
-{% set git_ref = 'master' if not READTHEDOCS or '.' not in current_version else 'v' + env.config.release %}
+{% set git_ref = 'master' if not READTHEDOCS else commit if '.' not in current_version else 'v' + env.config.release %}
 .. raw:: html
 
     <div class="admonition note">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ nbsphinx_execute_arguments = [
 napoleon_include_init_with_doc= False
 nbsphinx_timeout = 60
 
-# This is processed by Jinja2 and inserted before each notebook
+# This is processed by Jinja2, and inserted before each notebook
 nbsphinx_prolog = r"""
 {% set docname = 'docs/' + env.doc2path(env.docname, base=None) %}
 {% set git_ref = 'master' if not READTHEDOCS else 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ nbsphinx_execute_arguments = [
 napoleon_include_init_with_doc= False
 nbsphinx_timeout = 60
 
-# This is processed by Jinja2, and inserted before each notebook
+# This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = r"""
 {% set docname = 'docs/' + env.doc2path(env.docname, base=None) %}
 {% set git_ref = 'master' if not READTHEDOCS else 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,9 @@ nbsphinx_timeout = 60
 # This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = r"""
 {% set docname = 'docs/' + env.doc2path(env.docname, base=None) %}
-{% set git_ref = 'master' if not READTHEDOCS else commit if '.' not in current_version else 'v' + env.config.release %}
+{% set git_ref = 'master' if not READTHEDOCS else 
+                 commit if '.' not in current_version else
+                 'v' + env.config.release %}
 .. raw:: html
 
     <div class="admonition note">


### PR DESCRIPTION
It's not clear what broke this or whether it was ever supposed to be used the way we had it before.

If fixed, this should produce exact commit links in the header of https://clifford--401.org.readthedocs.build/en/401/tutorials/g3-algebra-of-space.html