### PR TITLE
Fix some warnings in the sphinx logs

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -224,7 +224,7 @@ class Layout(object):
         algebra.  This list determines the order of coefficients in the
         internal representation of multivectors.  The entry for the scalar
         must be an empty tuple, and the entries for grade-1 vectors must be
-        singleton tuples.  Remember, the length of the list will be ``2**dims`.
+        singleton tuples.  Remember, the length of the list will be ``2**dims``.
 
         Example::
 
@@ -266,8 +266,6 @@ class Layout(object):
         dimensionality of vectors (``len(self.sig)``)
     sig :
         normalized signature, with all values ``+1`` or ``-1``
-    bladeTupList :
-        list of blades
     gaDims :
         2**dims
     names :
@@ -673,8 +671,8 @@ class Layout(object):
         """
         Get a function that returns left-inverse using a computational linear algebra method
         proposed by Christian Perwass.
-         -1         -1
-        M    where M  * M  == 1
+
+        Computes :math:`M^{-1}` where :math:`M^{-1}M = 1`.
         """
         mult_table = self.gmt
         k_list, l_list, m_list = mult_table.coords

--- a/clifford/taylor_expansions.py
+++ b/clifford/taylor_expansions.py
@@ -18,13 +18,13 @@ and more accurate. Nonetheless, having pre-written taylor expansions for the gen
 
     For example::
 
-    >>> from clifford.g3 import *
-    >>> import numpy as np
-    >>> np.sin(np.pi*e12/4)
-    (0.86867^e12)
+        >>> from clifford.g3 import *
+        >>> import numpy as np
+        >>> np.sin(np.pi*e12/4)
+        (0.86867^e12)
 
 Implemented functions
-----------------
+---------------------
 
 .. autofunction:: exp
 .. autofunction:: sin

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,7 +43,7 @@ Compatibility notes
   and so ``mv[i]`` and ``len(mv)`` both emit :exc:`DeprecationWarning`s. If the underlying
   storage order is of interest, use ``mv.value[i]`` and ``len(mv)``respectively. To obtain the
   scalar part of a :class:`MultiVector`, use ``mv[()]`` instead of ``mv[0]``.
-* ``Layout.gradeList`` has been removed. If still needed, it can be recovered as an :type:`ndarray`
+* ``Layout.gradeList`` has been removed. If still needed, it can be recovered as an :class:`ndarray`
   isntead of a :class:`list` via the private attribute ``layout._basis_blade_order.grades``
   (:attr:`BasisBladeOrder.grades`).
 * This will be the last release to support Python 3.5, which reached its end-of-life during our

--- a/docs/tutorials/euler-angles.ipynb
+++ b/docs/tutorials/euler-angles.ipynb
@@ -253,7 +253,7 @@
    "metadata": {},
    "source": [
     "In 3 Dimenions, there is a simple formula which can be used to directly transform a rotations matrix into a rotor.\n",
-    "For arbitrary dimensions you have to use a different algorithm (see `clifford.tools.orthoMat2Versor()` ([docs](../generated/clifford.tools.orthoMat2Versor.rst))).\n",
+    "For arbitrary dimensions you have to use a different algorithm (see `clifford.tools.orthoMat2Versor()` ([docs](../api/generated/clifford.tools.orthoMat2Versor.rst))).\n",
     "Anyway, in 3 dimensions there is a closed form solution, as described in Sec. 4.3.3 of \"Geometric Algebra for Physicists\".\n",
     "Given a rotor $R$ which transforms an  orthonormal frame $A={a_k}$  into $B={b_k}$ as such,\n",
     "\n",

--- a/docs/tutorials/g3-algebra-of-space.ipynb
+++ b/docs/tutorials/g3-algebra-of-space.ipynb
@@ -34,7 +34,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we import clifford as `cf`, and instantiate a three dimensional geometric algebra using `Cl()` ([docs](../generated/clifford.Cl.rst))."
+    "First, we import clifford as `cf`, and instantiate a three dimensional geometric algebra using `Cl()` ([docs](../api/clifford.Cl.rst))."
    ]
   },
   {

--- a/docs/tutorials/space-time-algebra.ipynb
+++ b/docs/tutorials/space-time-algebra.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "This notebook demonstrates how to use `clifford` to work with Space Time Algebra.\n",
     "The Pauli algebra of space  $\\mathbb{P}$, and Dirac algebra of space-time $\\mathbb{D}$, are related using the *spacetime split*.\n",
-    "The split is implemented by using a `BladeMap` ([docs](../generated/clifford.BladeMap.html)), which maps a subset of blades in $\\mathbb{D}$ to the blades in $\\mathbb{P}$.\n",
+    "The split is implemented by using a `BladeMap` ([docs](../api/clifford.BladeMap.rst)), which maps a subset of blades in $\\mathbb{D}$ to the blades in $\\mathbb{P}$.\n",
     "This *split* allows a spacetime bivector $F$ to be broken up into relative electric and magnetic fields in space.\n",
     "Lorentz transformations are implemented as rotations in  $\\mathbb{D}$, and the effects on the relative fields are computed with the split. "
    ]


### PR DESCRIPTION
The list of warnings is something like:
```
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.rst:35: WARNING: autosummary: stub file not found 'clifford.BasisBladeOrder'. Check your autosummary_generate setting.
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.rst:35: WARNING: autosummary: stub file not found 'clifford.BasisVectorIds'. Check your autosummary_generate setting.
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.rst:57: WARNING: autosummary: stub file not found 'clifford.MVArray'. Check your autosummary_generate setting.
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/_layout.py:docstring of clifford._layout.Layout:39: WARNING: Inline literal start-string without end-string.
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/_layout.py:docstring of clifford.Layout.bladeTupList:1: WARNING: duplicate object description of clifford.Layout.bladeTupList, other instance in api/clifford.Layout, use :noindex: for one of them
docstring of clifford.Layout.inv_func:3: WARNING: Unexpected indentation.
docstring of clifford.Layout.inv_func:4: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.ep
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.en
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.eo
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.einf
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.E0
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.I_base
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/taylor_expansions.py:docstring of clifford.taylor_expansions:23: WARNING: Inconsistent literal block quoting.
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/403/lib/python3.8/site-packages/clifford/taylor_expansions.py:docstring of clifford.taylor_expansions:26: WARNING: Title underline too short.

Implemented functions
----------------
/home/docs/checkouts/readthedocs.org/user_builds/clifford/checkouts/403/docs/changelog.rst:46: WARNING: Unknown interpreted text role "type".
/home/docs/checkouts/readthedocs.org/user_builds/clifford/checkouts/403/docs/tutorials/euler-angles.ipynb:377: WARNING: File not found: 'generated/clifford.tools.orthoMat2Versor.rst'
/home/docs/checkouts/readthedocs.org/user_builds/clifford/checkouts/403/docs/tutorials/g3-algebra-of-space.ipynb:43: WARNING: File not found: 'generated/clifford.Cl.rst'
/home/docs/checkouts/readthedocs.org/user_builds/clifford/checkouts/403/docs/tutorials/space-time-algebra.ipynb:32: WARNING: File not found: 'generated/clifford.BladeMap.html'
```
This change fixes the broken links and formatting errors, leaving us with
```
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/406/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.rst:35: WARNING: autosummary: stub file not found 'clifford.BasisBladeOrder'. Check your autosummary_generate setting.
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/406/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.rst:35: WARNING: autosummary: stub file not found 'clifford.BasisVectorIds'. Check your autosummary_generate setting.
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/406/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.rst:57: WARNING: autosummary: stub file not found 'clifford.MVArray'. Check your autosummary_generate setting.
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/406/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.ep
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/406/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.en
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/406/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.eo
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/406/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.einf
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/406/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.E0
/home/docs/checkouts/readthedocs.org/user_builds/clifford/envs/406/lib/python3.8/site-packages/clifford/__init__.py:docstring of clifford.conformalize.rst:22: WARNING: autosummary: failed to import ConformalLayout.I_base
```
I think the ones which remain are all just hacks to get `autosummary` to behave how we wanted it to.