### PR TITLE
Pin Sphinx to workaround an nbsphinx incompatibility

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,10 @@ pandas
 ipykernel
 nbsphinx
 ipywidgets
-sphinx>=2.4
+
+# workaround for https://github.com/spatialaudio/nbsphinx/issues/584
+sphinx>=4.0.0,<4.1.0
+
 sphinx_rtd_theme>=0.5.0
 sphinxcontrib-bibtex>=2.3.0
 


### PR DESCRIPTION
Fixes #405, hopefully. We won't be able to tell for sure until this is merged to master, since the PR builds do not built the PDF version.

ReadTheDocs seems to build with Sphinx v4.0.3 using this config, which suggests the pinning is working.