### PR TITLE
Re-enable the no-JIT CI test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,10 +45,9 @@ jobs:
       matrix:
         include:
           # fastest jobs first
-          # This job currently fails
-          # - python-version: 3.8
-          #   name: without JIT
-          #   disable_jit: 1
+          - python-version: 3.8
+            name: without JIT
+            disable_jit: 1
           - python-version: 3.8
             name: doctests
             mode: doctests
@@ -70,7 +69,7 @@ jobs:
     name: "build | ${{ matrix.name }} | Python ${{matrix.python-version}}"
     steps:
     - uses: actions/checkout@v2
-    
+
     # python / pip
     - name: Set up Python ${{ matrix.python-version }}
       if: "!matrix.conda"
@@ -84,7 +83,7 @@ jobs:
         pip install . --prefer-binary;
         # test dependencies
         pip install --upgrade pytest pytest-cov pytest-benchmark IPython
-        
+
     # conda
     - name: Set up Python ${{ matrix.python-version }} (conda)
       if: matrix.conda

--- a/clifford/_numba_utils.py
+++ b/clifford/_numba_utils.py
@@ -27,7 +27,11 @@ class pickleable_function:
     Numba jitted functions are pickleable, so we should be too.
 
     Here we just reach into the internals of numba to pull out their
-    serialization helpers
+    serialization helpers.
+
+    .. warning::
+        This seems to no longer work in most versions of numba, see
+        gh-404.
     """
     def __new__(cls, func):
         if isinstance(func, pickleable_function):

--- a/clifford/test/test_tools_classify.py
+++ b/clifford/test/test_tools_classify.py
@@ -27,7 +27,7 @@ class _TestBase:
     def radius(self, request):
         return request.param
 
-    def _test_roundrip(self, cls, g, **kwargs):
+    def _test_roundtrip(self, cls, g, **kwargs):
         b = cls[g](**kwargs)
         b_rt = classify(b.mv)
         assert isinstance(b_rt, cls)
@@ -45,28 +45,28 @@ class _TestBase:
 
     def test_roundtrip_direction(self, direction):
         g = _grade(direction)
-        self._test_roundrip(
+        self._test_roundtrip(
             Direction, g + 1,
             direction=direction,
         )
 
     def test_roundtrip_round(self, direction, location, radius):
         g = _grade(direction)
-        self._test_roundrip(
+        self._test_roundtrip(
             Round, g + 1,
             direction=direction, location=location, radius=radius,
         )
 
     def test_roundtrip_flat(self, direction, location):
         g = _grade(direction)
-        self._test_roundrip(
+        self._test_roundtrip(
             Flat, g + 2,
             direction=direction, location=location,
         )
 
     def test_roundtrip_dual_flat(self, direction, location):
         g = _grade(direction)
-        self._test_roundrip(
+        self._test_roundtrip(
             DualFlat, self.layout.dims - (g + 2),
             flat=Flat(direction=direction, location=location),
         )


### PR DESCRIPTION
It seems the pickling hacks are broken, so I've added some more hacks on top of them to make that not matter.

What this means is that when running in no-jit mode, pickled `Layout` objects no longer contain an attempt at pickling cached operators. The pickle file continues to hold cached multiplication tables.

The regular jit mode is unaffected, as there is perhaps some value to pickling the compiled routines.

This works around #404

---

CI run: https://github.com/pygae/clifford/pull/408/checks?check_run_id=3115660735