### PR TITLE
numba: inverse functions, layout attributes, and better constructors

### DIFF
--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -591,9 +591,9 @@ class Layout(object):
     @_cached_property
     def _hitzer_inverse(self):
         """ See `MultiVector.hitzer_inverse` for documentation """
-        tot = len(self.sig)
         @_numba_utils.njit
         def hitzer_inverse(operand):
+            tot = operand.layout.dims
             if tot == 0:
                 numerator = 1 + 0*operand
             elif tot == 1:

--- a/clifford/numba/__init__.py
+++ b/clifford/numba/__init__.py
@@ -35,8 +35,12 @@ Supported operations
 --------------------
 The following list of operations are supported in a jitted context:
 
-* A limited version of the constructor ``MultiVector(layout, value)``, and
-  the alias :meth:`layout.MultiVector`.
+* :class:`MultiVector`: A limited version of the constructor supporting only
+  ``MultiVector(layout, value)`` and ``MultiVector(layout, dtype=dtype)``.
+* :meth:`layout.MultiVector`, with the same caveats as above.
+* :attr:`layout.dims`
+* :attr:`layout.gaDims`
+* :attr:`layout.sig`
 * :attr:`MultiVector.value`
 * :attr:`MultiVector.layout`
 * Arithmetic:

--- a/clifford/numba/__init__.py
+++ b/clifford/numba/__init__.py
@@ -56,8 +56,15 @@ The following list of operations are supported in a jitted context:
 * :meth:`MultiVector.mag2`
 * :meth:`MultiVector.__abs__`
 * :meth:`MultiVector.normal`
+* :meth:`MultiVector.leftLaInv`
+* :meth:`MultiVector.shirokov_inverse`
+* :meth:`MultiVector.hitzer_inverse`
 * :meth:`MultiVector.gradeInvol`
 * :meth:`MultiVector.conjugate`
+* :meth:`MultiVector.commutator`
+* :meth:`MultiVector.anticommutator`
+* :attr:`MultiVector.even`
+* :attr:`MultiVector.odd`
 
 Performance considerations
 --------------------------

--- a/clifford/numba/_layout.py
+++ b/clifford/numba/_layout.py
@@ -80,7 +80,32 @@ def box_Layout(typ: LayoutType, val: llvmlite.ir.Value, c) -> Layout:
 # methods
 
 @numba.extending.overload_method(LayoutType, 'MultiVector')
-def Layout_MultiVector(self, value):
-    def impl(self, value):
-        return MultiVector(self, value)
+def Layout_MultiVector(self, value=None, dtype=None):
+    def impl(self, value=None, dtype=None):
+        return MultiVector(self, value, dtype)
+    return impl
+
+# attributes
+
+@numba.extending.overload_attribute(LayoutType, 'sig')
+def Layout_sig(self):
+    val = self.obj.sig
+    def impl(self):
+        return val
+    return impl
+
+
+@numba.extending.overload_attribute(LayoutType, 'dims')
+def Layout_dims(self):
+    val = self.obj.dims
+    def impl(self):
+        return val
+    return impl
+
+
+@numba.extending.overload_attribute(LayoutType, 'gaDims')
+def Layout_gaDims(self):
+    val = self.obj.gaDims
+    def impl(self):
+        return val
     return impl

--- a/clifford/numba/_multivector.py
+++ b/clifford/numba/_multivector.py
@@ -363,12 +363,65 @@ def MultiVector_normal(self):
 
 @numba.extending.overload_method(MultiVectorType, 'gradeInvol')
 def MultiVector_gradeInvol(self):
-    g_func = self.layout_type.obj._grade_invol
-    def impl(self):
-        return g_func(self)
-    return impl
+    if isinstance(self, MultiVectorType):
+        g_func = self.layout_type.obj._grade_invol
+        def impl(self):
+            return g_func(self)
+        return impl
 
 
 @numba.extending.overload_method(MultiVectorType, 'conjugate')
 def MultiVector_conjugate(self):
     return MultiVector.conjugate
+
+
+@numba.extending.overload_attribute(MultiVectorType, 'even')
+def MultiVector_even(self):
+    return MultiVector.even.fget
+
+
+@numba.extending.overload_attribute(MultiVectorType, 'odd')
+def MultiVector_odd(self):
+    return MultiVector.odd.fget
+
+
+@numba.extending.overload_method(MultiVectorType, 'conjugate')
+def MultiVector_conjugate(self):
+    return MultiVector.conjugate
+
+
+@numba.extending.overload_method(MultiVectorType, 'commutator')
+def MultiVector_commutator(self, other):
+    return MultiVector.commutator
+
+
+@numba.extending.overload_method(MultiVectorType, 'anticommutator')
+def MultiVector_commutator(self, other):
+    return MultiVector.anticommutator
+
+
+@numba.extending.overload_method(MultiVectorType, 'leftLaInv')
+def MultiVector_leftLaInv(self):
+    if isinstance(self, MultiVectorType):
+        inv_func = self.layout_type.obj.inv_func
+        def impl(self):
+            return self.layout.MultiVector(inv_func(self.value))
+        return impl
+
+
+@numba.extending.overload_method(MultiVectorType, 'hitzer_inverse')
+def MultiVector_hitzer_inverse(self):
+    if isinstance(self, MultiVectorType):
+        func = self.layout_type.obj._hitzer_inverse
+        def impl(self):
+            return func(self)
+        return impl
+
+
+@numba.extending.overload_method(MultiVectorType, 'shirokov_inverse')
+def MultiVector_shirokov_inverse(self):
+    if isinstance(self, MultiVectorType):
+        func = self.layout_type.obj._shirokov_inverse
+        def impl(self):
+            return func(self)
+        return impl

--- a/clifford/test/test_numba_extensions.py
+++ b/clifford/test/test_numba_extensions.py
@@ -2,6 +2,7 @@ import operator
 import pickle
 
 import numba
+import numpy as np
 import pytest
 
 from clifford.g3c import layout, e1, e2, e3, e4, e5
@@ -59,15 +60,44 @@ class TestBasic:
 
         assert_mv_equal(add_e1(e2), e1 + e2)
 
+
+class TestLayout:
+
     def test_multivector_shorthand(self):
         @numba.njit
         def double(a):
             return a.layout.MultiVector(a.value*2)
 
+        @numba.njit
+        def czeros(l):
+            return l.MultiVector(dtype=np.complex64)
+
         assert_mv_equal(double(e2), 2 * e2)
+        assert_mv_equal(czeros(layout), layout.MultiVector(dtype=np.complex64))
+
+    def test_sig(self):
+        @numba.njit
+        def jit_func(a):
+            return layout.sig
+
+        assert list(jit_func(layout)) == list(layout.sig)
+
+    def test_dims(self):
+        @numba.njit
+        def jit_func(a):
+            return layout.dims
+
+        assert jit_func(layout) == layout.dims
+
+    def test_gaDims(self):
+        @numba.njit
+        def jit_func(a):
+            return layout.gaDims
+
+        assert jit_func(layout) == layout.gaDims
 
 
-class TestOperators:
+class TestMultiVectorOperators:
     @pytest.mark.parametrize("op", [
         pytest.param(getattr(operator, op), id=op)
         for op in ['add', 'sub', 'mul', 'xor', 'or_']
@@ -152,7 +182,7 @@ class TestOperators:
         assert func(a, 0, 1, 2, 3, 4, 5) == a
 
 
-class TestMethods:
+class TestMultiVectorMethods:
     def test_leftLaInv(self):
         @numba.njit
         def jit_func(a):
@@ -208,7 +238,7 @@ class TestMethods:
         assert_mv_equal(a.anticommutator(b), jit_func(a, b))
 
 
-class TestProperties:
+class TestMultiVectorProperties:
 
     @pytest.mark.parametrize('v', [1 + e1 + e2*e3, 1.0 + e1])
     def test_even(self, v):


### PR DESCRIPTION
This adds numba extension support for:
* A handful of `MultiVector` methods and attributes via straightforward wrappers.
  Within these, we only do `if isinstance(self, MultiVectorType):` in the functions where we rely on the existence of `self.layout_type`.
* Some `Layout` attributes via straightforward wrappers.
* The dtype argument to `MultiVector`