### PR TITLE
Fix GitHub workflow CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
     name: "lint | Python ${{ matrix.python-version }}"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -45,37 +45,37 @@ jobs:
       matrix:
         include:
           # fastest jobs first
-          - python-version: 3.8
+          - python-version: 3.11
             name: without JIT
             disable_jit: 1
-          - python-version: 3.8
+          - python-version: 3.11
             name: doctests
             mode: doctests
           # really slow job next, so it runs in parallel with the others
-          - python-version: 3.8
+          - python-version: 3.11
             name: slow tests
             mode: very_slow
-          - python-version: 3.5
-            name: default
           - python-version: 3.8
             name: default
-          - python-version: 3.9
+          - python-version: 3.11
             name: default
-          - python-version: 3.8
+          - python-version: 3.12
+            name: default
+          - python-version: 3.11
             name: conda
             conda: true
-          - python-version: 3.8
+          - python-version: 3.11
             name: benchmarks
             mode: bench
 
     name: "build | ${{ matrix.name }} | Python ${{matrix.python-version}}"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # python / pip
     - name: Set up Python ${{ matrix.python-version }}
       if: "!matrix.conda"
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -89,7 +89,7 @@ jobs:
     # conda
     - name: Set up Python ${{ matrix.python-version }} (conda)
       if: matrix.conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
@@ -146,16 +146,16 @@ jobs:
     #   if: ${{ always() }}
     #   with:
     #     report_paths: 'junit/test-results.xml'
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v5
 
   deploy:
     needs: test
     runs-on: ubuntu-latest
     name: deploy
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: "Install"
@@ -163,7 +163,7 @@ jobs:
         python -m pip install --upgrade pip;
         python -m pip install build
         python -m build --sdist --wheel --outdir dist/
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist

--- a/clifford/_conformal_layout.py
+++ b/clifford/_conformal_layout.py
@@ -66,7 +66,7 @@ class ConformalLayout(Layout):
                 new_val = np.zeros(self.gaDims)
                 new_val[:len(old_val)] = old_val
                 x = self.MultiVector(value=new_val)
-        except(AttributeError):
+        except (AttributeError):
             # if x is a scalar it does not have layout but following
             # will still work
             pass

--- a/clifford/cga.py
+++ b/clifford/cga.py
@@ -399,7 +399,7 @@ class Dilation(CGAThing):
                     arg = float(arg)
 
             if arg < 0:
-                raise(ValueError('dilation should be positive'))
+                raise (ValueError('dilation should be positive'))
 
             mv = e**((-log(arg)/2.)*(self.cga.E0))
 

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -220,7 +220,7 @@ class TestClifford:
         # check properties of the array are preserved (no need to check both a and b)
         np.testing.assert_array_equal(mv_array_a.value, value_array_a)
         assert mv_array_a.value.dtype == value_array_a.dtype
-        assert type(mv_array_a.value) == type(value_array_a)
+        assert type(mv_array_a.value) is type(value_array_a)
 
         # Check addition
         mv_array_sum = mv_array_a + mv_array_b
@@ -806,9 +806,9 @@ class TestFrame:
         for m, a in enumerate(A):
             for n, b in enumerate(A.inv):
                 if m == n:
-                    assert(a | b == 1)
+                    assert (a | b == 1)
                 else:
-                    assert(a | b == 0)
+                    assert (a | b == 0)
 
     @pytest.mark.parametrize(('p', 'q'), [
         (2, 0), (3, 0), (4, 0)

--- a/clifford/test/test_g3c_tools.py
+++ b/clifford/test/test_g3c_tools.py
@@ -1,4 +1,3 @@
-import random
 from functools import reduce
 import time
 import functools
@@ -6,15 +5,11 @@ import functools
 
 import numpy as np
 import numpy.testing as npt
-from numpy import exp
 import pytest
-import numba
 
-from clifford import Cl
 from clifford.g3c import *
 from clifford.tools.g3c import *
-from clifford.tools.g3c.rotor_parameterisation import ga_log, ga_exp, general_logarithm, \
-    interpolate_rotors
+from clifford.tools.g3c.rotor_parameterisation import ga_log, general_logarithm
 from clifford.tools.g3c.rotor_estimation import *
 from clifford.tools.g3c.object_clustering import *
 from clifford.tools.g3c.scene_simplification import *
@@ -175,7 +170,7 @@ class TestGeneralLogarithm:
             V = (T * R * S).normal()
             biv = general_logarithm(V)
             V_rebuilt = biv.exp().normal()
-            biv2 = general_logarithm(V)
+            _ = general_logarithm(V)
 
             C1 = random_point_pair(rng=rng)
             C2 = (V * C1 * ~V).normal()
@@ -381,8 +376,8 @@ class TestG3CTools:
         for _ in range(100):
             C1 = random_circle(rng=rng)
             C2 = random_circle(rng=rng)
-            pclose = iterative_closest_points_on_circles(C1, C2)
-            pfar = iterative_furthest_points_on_circles(C1, C2)
+            _ = iterative_closest_points_on_circles(C1, C2)
+            _ = iterative_furthest_points_on_circles(C1, C2)
 
     def test_closest_points_circle_line(self, rng):  # noqa: F811
         """
@@ -740,7 +735,7 @@ class TestG3CTools:
         rad = get_radius_from_sphere(C1)
         t_r = generate_translation_rotor(2.5*rad*e1)
         C2 = (t_r * C1 * ~t_r)(4).normal()
-        rad2 = get_radius_from_sphere(C2)
+        _ = get_radius_from_sphere(C2)
         R = rotor_between_objects(C1, C2)
         C3 = (R * C1 * ~R).normal()
         if sum(np.abs((C2 + C3).value)) < 0.0001:
@@ -1021,7 +1016,7 @@ class TestObjectClustering:
 
         n_repeats = 5
         for i in range(n_repeats):
-            r = random_rotation_translation_rotor(0.001, np.pi / 32, rng=rng)
+            _ = random_rotation_translation_rotor(0.001, np.pi / 32, rng=rng)
             object_set_a = [obj_gen(rng=rng) for i in range(20)]
             object_set_b = [l for l in object_set_a]
             label_a, costs_a = assign_measurements_to_objects_matrix(object_set_a, object_set_b)

--- a/clifford/tools/g3c/rotor_estimation.py
+++ b/clifford/tools/g3c/rotor_estimation.py
@@ -1,5 +1,4 @@
 import random
-from scipy import e
 import numpy as np
 import multiprocessing
 
@@ -379,7 +378,7 @@ def cartans_lines(obj_list_a, obj_list_b):
     """ Performs the extended cartans algorithm as suggested by Alex Arsenovic """
     V_found, rs = cartan(A=obj_list_a, B=obj_list_b)
     theta = ((V_found*~V_found)*e1234)(0)
-    V_found = e**(-theta/2*e123inf)*V_found
+    V_found = np.e**(-theta/2*e123inf)*V_found
     return V_found
 
 


### PR DESCRIPTION
Currently, CI fails because of following reasons:

- Workflow job "lint" job, step "Run flake8" detects some code quality issues
- Workflow uses python 3.5, which is no longer supported by GitHub actions runner
- tools/rotor_estimation.py imports `scipy.e`, which is no longer present (see https://github.com/scipy/scipy/commit/6e207a1)

This change also avoids some warnings about outdated GitHub actions versions.