### PR TITLE
Replace the deprecated @generated_jit by @njit

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
     name: "lint | Python ${{ matrix.python-version }}"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -45,37 +45,37 @@ jobs:
       matrix:
         include:
           # fastest jobs first
-          - python-version: 3.8
+          - python-version: 3.11
             name: without JIT
             disable_jit: 1
-          - python-version: 3.8
+          - python-version: 3.11
             name: doctests
             mode: doctests
           # really slow job next, so it runs in parallel with the others
-          - python-version: 3.8
+          - python-version: 3.11
             name: slow tests
             mode: very_slow
-          - python-version: 3.5
-            name: default
           - python-version: 3.8
             name: default
-          - python-version: 3.9
+          - python-version: 3.11
             name: default
-          - python-version: 3.8
+          - python-version: 3.12
+            name: default
+          - python-version: 3.11
             name: conda
             conda: true
-          - python-version: 3.8
+          - python-version: 3.11
             name: benchmarks
             mode: bench
 
     name: "build | ${{ matrix.name }} | Python ${{matrix.python-version}}"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # python / pip
     - name: Set up Python ${{ matrix.python-version }}
       if: "!matrix.conda"
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -89,7 +89,7 @@ jobs:
     # conda
     - name: Set up Python ${{ matrix.python-version }} (conda)
       if: matrix.conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
@@ -146,16 +146,16 @@ jobs:
     #   if: ${{ always() }}
     #   with:
     #     report_paths: 'junit/test-results.xml'
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v5
 
   deploy:
     needs: test
     runs-on: ubuntu-latest
     name: deploy
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: "Install"
@@ -163,7 +163,7 @@ jobs:
         python -m pip install --upgrade pip;
         python -m pip install build
         python -m build --sdist --wheel --outdir dist/
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist

--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -172,19 +172,14 @@ def _get_mult_function(mt: sparse.COO):
     k_list, l_list, m_list = mt.coords
     mult_table_vals = mt.data
 
-    @_numba_utils.generated_jit(nopython=True)
+    @_numba_utils.njit
     def mv_mult(value, other_value):
-        # this casting will be done at jit-time
-        ret_dtype = _get_mult_function_result_type(value, other_value, mult_table_vals.dtype)
-        mult_table_vals_t = mult_table_vals.astype(ret_dtype)
-
-        def mult_inner(value, other_value):
-            output = np.zeros(dims, dtype=ret_dtype)
-            for k, l, m, val in zip(k_list, l_list, m_list, mult_table_vals_t):
-                output[l] += value[k] * val * other_value[m]
-            return output
-
-        return mult_inner
+        res = value[k_list] * mult_table_vals * other_value[m_list]
+        output = np.zeros(dims, dtype=res.dtype)
+        # Can not use "np.add.at(output, l_list, res)", as ufunc.at is not supported by numba
+        for l, val in zip(l_list, res):
+            output[l] += val
+        return output
 
     return mv_mult
 
@@ -203,24 +198,16 @@ def _get_mult_function_runtime_sparse(mt: sparse.COO):
     k_list, l_list, m_list = mt.coords
     mult_table_vals = mt.data
 
-    @_numba_utils.generated_jit(nopython=True)
+    @_numba_utils.njit
     def mv_mult(value, other_value):
-        # this casting will be done at jit-time
-        ret_dtype = _get_mult_function_result_type(value, other_value, mult_table_vals.dtype)
-        mult_table_vals_t = mult_table_vals.astype(ret_dtype)
-
-        def mult_inner(value, other_value):
-            output = np.zeros(dims, dtype=ret_dtype)
-            for ind, k in enumerate(k_list):
-                v_val = value[k]
-                if v_val != 0.0:
-                    m = m_list[ind]
-                    ov_val = other_value[m]
-                    if ov_val != 0.0:
-                        l = l_list[ind]
-                        output[l] += v_val * mult_table_vals_t[ind] * ov_val
-            return output
-        return mult_inner
+        # Use mask where both operands are non-zero, to avoid zero-multiplications
+        nz_mask = (value != 0.0)[k_list] & (other_value != 0.0)[m_list]
+        res = value[k_list[nz_mask]] * mult_table_vals[nz_mask] * other_value[m_list[nz_mask]]
+        output = np.zeros(dims, dtype=res.dtype)
+        # Can not use "np.add.at(output, l_list[nz_mask], res)", as ufunc.at is not supported by numba
+        for l, val in zip(l_list[nz_mask], res):
+            output[l] += val
+        return output
 
     return mv_mult
 

--- a/clifford/__init__.py
+++ b/clifford/__init__.py
@@ -81,12 +81,7 @@ from typing import List, Tuple, Set, Dict
 
 # Major library imports.
 import numpy as np
-import numba as _numba  # to avoid clashing with clifford.numba
 import sparse
-try:
-    from numba.np import numpy_support as _numpy_support
-except ImportError:
-    import numba.numpy_support as _numpy_support
 
 
 from clifford.io import write_ga_file, read_ga_file  # noqa: F401
@@ -150,12 +145,6 @@ def get_mult_function(mt: sparse.COO, gradeList,
 
     else:
         return _get_mult_function_runtime_sparse(mt)
-
-
-def _get_mult_function_result_type(a: _numba.types.Type, b: _numba.types.Type, mt: np.dtype):
-    a_dt = _numpy_support.as_dtype(getattr(a, 'dtype', a))
-    b_dt = _numpy_support.as_dtype(getattr(b, 'dtype', b))
-    return np.result_type(a_dt, mt, b_dt)
 
 
 def _get_mult_function(mt: sparse.COO):

--- a/clifford/_conformal_layout.py
+++ b/clifford/_conformal_layout.py
@@ -66,7 +66,7 @@ class ConformalLayout(Layout):
                 new_val = np.zeros(self.gaDims)
                 new_val[:len(old_val)] = old_val
                 x = self.MultiVector(value=new_val)
-        except(AttributeError):
+        except (AttributeError):
             # if x is a scalar it does not have layout but following
             # will still work
             pass

--- a/clifford/_conformal_layout.py
+++ b/clifford/_conformal_layout.py
@@ -66,7 +66,7 @@ class ConformalLayout(Layout):
                 new_val = np.zeros(self.gaDims)
                 new_val[:len(old_val)] = old_val
                 x = self.MultiVector(value=new_val)
-        except (AttributeError):
+        except AttributeError:
             # if x is a scalar it does not have layout but following
             # will still work
             pass

--- a/clifford/_layout.py
+++ b/clifford/_layout.py
@@ -479,7 +479,7 @@ class Layout(object):
     def __repr__(self):
         return "{}({!r}, ids={!r}, order={!r}, names={!r})".format(
             type(self).__name__,
-            list(self.sig), self._basis_vector_ids, self._basis_blade_order, self.names
+            self.sig.tolist(), self._basis_vector_ids, self._basis_blade_order, self.names
         )
 
     def _repr_pretty_(self, p, cycle):
@@ -489,7 +489,7 @@ class Layout(object):
         prefix = '{}('.format(type(self).__name__)
 
         with p.group(len(prefix), prefix, ')'):
-            p.text('{},'.format(list(self.sig)))
+            p.text('{},'.format(self.sig.tolist()))
             p.breakable()
             p.text('ids=')
             p.pretty(self._basis_vector_ids)

--- a/clifford/_multivector.py
+++ b/clifford/_multivector.py
@@ -579,7 +579,7 @@ class MultiVector(object):
                 p.pretty(self.layout)
                 p.text(",")
                 p.breakable()
-            p.text(repr(list(self.value)))
+            p.text(repr(self.value.tolist()))
             if self.value.dtype != np.float64:
                 p.text(",")
                 p.breakable()

--- a/clifford/cga.py
+++ b/clifford/cga.py
@@ -399,7 +399,7 @@ class Dilation(CGAThing):
                     arg = float(arg)
 
             if arg < 0:
-                raise (ValueError('dilation should be positive'))
+                raise ValueError('dilation should be positive')
 
             mv = e**((-log(arg)/2.)*(self.cga.E0))
 

--- a/clifford/cga.py
+++ b/clifford/cga.py
@@ -399,7 +399,7 @@ class Dilation(CGAThing):
                     arg = float(arg)
 
             if arg < 0:
-                raise(ValueError('dilation should be positive'))
+                raise (ValueError('dilation should be positive'))
 
             mv = e**((-log(arg)/2.)*(self.cga.E0))
 

--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -220,7 +220,7 @@ class TestClifford:
         # check properties of the array are preserved (no need to check both a and b)
         np.testing.assert_array_equal(mv_array_a.value, value_array_a)
         assert mv_array_a.value.dtype == value_array_a.dtype
-        assert type(mv_array_a.value) == type(value_array_a)
+        assert type(mv_array_a.value) is type(value_array_a)
 
         # Check addition
         mv_array_sum = mv_array_a + mv_array_b
@@ -806,9 +806,9 @@ class TestFrame:
         for m, a in enumerate(A):
             for n, b in enumerate(A.inv):
                 if m == n:
-                    assert(a | b == 1)
+                    assert (a | b == 1)
                 else:
-                    assert(a | b == 0)
+                    assert (a | b == 0)
 
     @pytest.mark.parametrize(('p', 'q'), [
         (2, 0), (3, 0), (4, 0)

--- a/clifford/test/test_function_cache.py
+++ b/clifford/test/test_function_cache.py
@@ -1,19 +1,15 @@
 import numpy as np
-from clifford._numba_utils import generated_jit
+from clifford._numba_utils import njit
 import pytest
 
 
-@generated_jit(cache=True)
-def foo(x):
-    from clifford.g3 import e3
-
-    def impl(x):
-        return (x * e3).value
-    return impl
+@njit(cache=True)
+def foo(x, y):
+    return (x * y).value
 
 
 # Make the test fail on a failed cache warning
 @pytest.mark.filterwarnings("error")
 def test_function_cache():
     from clifford.g3 import e3
-    np.testing.assert_array_equal((1.0*e3).value, foo(1.0))
+    np.testing.assert_array_equal((1.0*e3).value, foo(1.0, e3))

--- a/clifford/test/test_g3c_tools.py
+++ b/clifford/test/test_g3c_tools.py
@@ -1,4 +1,3 @@
-import random
 from functools import reduce
 import time
 import functools
@@ -6,15 +5,11 @@ import functools
 
 import numpy as np
 import numpy.testing as npt
-from numpy import exp
 import pytest
-import numba
 
-from clifford import Cl
 from clifford.g3c import *
 from clifford.tools.g3c import *
-from clifford.tools.g3c.rotor_parameterisation import ga_log, ga_exp, general_logarithm, \
-    interpolate_rotors
+from clifford.tools.g3c.rotor_parameterisation import ga_log, general_logarithm
 from clifford.tools.g3c.rotor_estimation import *
 from clifford.tools.g3c.object_clustering import *
 from clifford.tools.g3c.scene_simplification import *
@@ -175,7 +170,7 @@ class TestGeneralLogarithm:
             V = (T * R * S).normal()
             biv = general_logarithm(V)
             V_rebuilt = biv.exp().normal()
-            biv2 = general_logarithm(V)
+            _ = general_logarithm(V)
 
             C1 = random_point_pair(rng=rng)
             C2 = (V * C1 * ~V).normal()
@@ -381,8 +376,8 @@ class TestG3CTools:
         for _ in range(100):
             C1 = random_circle(rng=rng)
             C2 = random_circle(rng=rng)
-            pclose = iterative_closest_points_on_circles(C1, C2)
-            pfar = iterative_furthest_points_on_circles(C1, C2)
+            _ = iterative_closest_points_on_circles(C1, C2)
+            _ = iterative_furthest_points_on_circles(C1, C2)
 
     def test_closest_points_circle_line(self, rng):  # noqa: F811
         """
@@ -740,7 +735,7 @@ class TestG3CTools:
         rad = get_radius_from_sphere(C1)
         t_r = generate_translation_rotor(2.5*rad*e1)
         C2 = (t_r * C1 * ~t_r)(4).normal()
-        rad2 = get_radius_from_sphere(C2)
+        _ = get_radius_from_sphere(C2)
         R = rotor_between_objects(C1, C2)
         C3 = (R * C1 * ~R).normal()
         if sum(np.abs((C2 + C3).value)) < 0.0001:
@@ -1021,7 +1016,7 @@ class TestObjectClustering:
 
         n_repeats = 5
         for i in range(n_repeats):
-            r = random_rotation_translation_rotor(0.001, np.pi / 32, rng=rng)
+            _ = random_rotation_translation_rotor(0.001, np.pi / 32, rng=rng)
             object_set_a = [obj_gen(rng=rng) for i in range(20)]
             object_set_b = [l for l in object_set_a]
             label_a, costs_a = assign_measurements_to_objects_matrix(object_set_a, object_set_b)

--- a/clifford/tools/g3c/rotor_estimation.py
+++ b/clifford/tools/g3c/rotor_estimation.py
@@ -1,5 +1,4 @@
 import random
-from scipy import e
 import numpy as np
 import multiprocessing
 
@@ -379,7 +378,7 @@ def cartans_lines(obj_list_a, obj_list_b):
     """ Performs the extended cartans algorithm as suggested by Alex Arsenovic """
     V_found, rs = cartan(A=obj_list_a, B=obj_list_b)
     theta = ((V_found*~V_found)*e1234)(0)
-    V_found = e**(-theta/2*e123inf)*V_found
+    V_found = np.e**(-theta/2*e123inf)*V_found
     return V_found
 
 


### PR DESCRIPTION
The branch is based on the PR#438 "Fix GitHub workflow CI", instead of on the `master`, just to run the CI tests. If it's too messy, I'll create another branch/PR. 

### Some details about the changes

Seems like, the only reason for using the `@generated_git` (instead of `@njit`) is that `numpy.result_type()` is not supported by numba.
Here, the use of this function is avoid by rewriting the original `mv_mult.mult_inner()` to:

1. perform the multiplication on all values pointed by `k_list` / `m_list` in a single ndarray operation
2. use whatever `dtype` is selected by numpy as an `output` dtype

This makes both `mv_mult()` instances much more compact and faster in DISABLE_JIT mode. In `_get_mult_function_runtime_sparse.mv_mult()`, there is an attempt to mimic the original trick to avoid multiplication-by-zero.


### Additional comments

- As an alternative, it is possible to use the `@overload` approach, as recommended here 
https://numba.readthedocs.io/en/stable/reference/deprecation.html#replacement. This will make the code somehow similar to existing implementation, but it would become even more complicated.

- The test in `test_function_cache.py` is just hacked to make it pass. I'm not sure about the purpose of this test.

- The GitHub workflow is still NOT expected to be fully successful, as it needs an extra fix for `numpy>=2.0`.
  This extra issue is related to the printing of numeric scalars with their type information (like 'np.int64(1)').
  It become quite messy, please excuse me for it.

Fixes #430