### PR TITLE
Fix readthedocs Webhook failure

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -15,7 +21,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,8 +5,7 @@ ipykernel
 nbsphinx
 ipywidgets
 
-# workaround for https://github.com/spatialaudio/nbsphinx/issues/584
-sphinx>=4.0.0,<4.1.0
+sphinx>=4.0.0
 
 sphinx_rtd_theme>=0.5.0
 sphinxcontrib-bibtex>=2.3.0


### PR DESCRIPTION
This is to fix the annoying failure when creating PRs.

The "readthedocs" server, seems to require a `build.os` parameters, as answered [here](https://github.com/readthedocs/readthedocs.org/issues/11173).

I changed the Python version to 3.9, just to have a longer live-span (it needed to drop `sphinx` version limit).
Migration to a later python version need more work, not sure if this is really needed.

In addition, the now obsolete `numba~=0.48.0` note can be removed from here: https://clifford.readthedocs.io/en/latest/installation.html#pypi