### PR TITLE
Simplify the test for swapped operand operations

### DIFF
--- a/clifford/test/test_clifford.py
+++ b/clifford/test/test_clifford.py
@@ -748,16 +748,20 @@ class TestBasicAlgebra:
         operator.xor,  # outer product
         operator.or_,  # inner product
     ])
-    def test_swapped_operands(self, algebra, rng, func):    # noqa: F811
-        layout = algebra
-        for _ in range(10):
-            mv = layout.randomMV(rng=rng)
-            mv2 = layout.randomMV(rng=rng)
-            # Convert first operand to MVArray. This provokes use of operation with
-            # swapped operands: MultiVector.__rmul__, __ror__, etc.
-            ma = clifford.MVArray(mv)
-            np.testing.assert_equal(func(ma, mv2), func(mv, mv2))
-            np.testing.assert_equal(func(mv2, ma), func(mv2, mv))
+    def test_swapped_operands(self, g3, func):
+        layout = g3
+        e1 = layout.blades['e1']
+        e2 = layout.blades['e2']
+        e12 = layout.blades['e12']
+        # Pick two numbers with non-commutative products
+        # e1^e2 == -e2^e1, e1|e12 == -e12|e1
+        mv = 1 * e1 + 2 * e2
+        mv2 = 3 * e1 + 5 * e12
+        # Convert first operand to MVArray. This provokes use of operation with
+        # swapped operands: MultiVector.__rmul__, __ror__, etc.
+        ma = clifford.MVArray(mv)
+        np.testing.assert_equal(func(ma, mv2), func(mv, mv2))
+        np.testing.assert_equal(func(mv2, ma), func(mv2, mv))
 
 
 class TestPrettyRepr:


### PR DESCRIPTION
This is a follow up for PR#437.

The pytest `TestBasicAlgebra.test_swapped_operands()` is too complicated. As suggested by @eric-wieser, the validation can be made by using some picked /convenient numbers from `g3` only.