### PR TITLE
chore: bump version to v1.5.0

### DIFF
--- a/clifford/_version.py
+++ b/clifford/_version.py
@@ -5,4 +5,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module
-__version__ = '1.5.0dev0'
+__version__ = '1.5.0'


### PR DESCRIPTION
Based on the previous commits / releases, it looks like the following need to happen for a release:
- [x] The version number needs to be bumped from `1.5.0.dev0` from `1.5.0`
- [ ] A `maintenance/1.5.x` branch needs to be created
- [ ] When this PR is merged, it needs to be tagged as `v1.5.0` to activate the github actions workflow that should upload to pypi (assuming `secrets.PYPI_PASSWORD` hasn't expired / been revoked)
- [ ] Master could be tagged now as `v1.5.0dev0` to test that secret works and we can make a prerelease to pypi (I see [v1.4.0dev0](https://pypi.org/project/clifford/#history) was a prerelease
- [ ] Release notes in [docs/changelog.rst](docs/changelog.rst) need to be written. These are the commits _I think_ should be documented. Mostly they're PR merges, so it's easy to find some details about them. 
	* 8c41854 (HEAD -> master) Simplify the test for swapped operand operations (#441)
	* 57e9e49 Merge pull request #437 from trundev/fix-pygae-426
	* cc2590c Merge pull request #439 from trundev/drop-generated_jit
	* 9e47ec2 Merge pull request #432 from fchapoton/typos1
	* 6939f2a Merge pull request #435 from fchapoton/patch-1
	* 3b5f83a Merge pull request #365 from kliment/master
	* 1102eba Rename *_gmt_matrix to *_mt_matrix for cases not specific to the geometric product (#419)
	* 8b1428c bug: fix compatibility with numba 0.55 (#420)
	* 3d7920e docs: fix transposition error in euler angles tutorial (#417)
	* e63f856 Merge pull request #414 from eric-wieser/fix-numba-0.54.0
	* 9e8fcf2 Merge pull request #412 from eric-wieser/jit-la-inv
	* 116685e Syntax highlight
	* 497e235 Remove citation info from readme now that github has a better place for it.
    * <details><summary>I considered the logs from <code>v1.4.0..master</code>, shown below with an <code>x</code> for commits I think are of interest (or at <a href="https://github.com/pygae/clifford/compare/v1.4.0...master">this link</a>)</summary>

		```
		x   * 8c41854 (HEAD -> master, github/master, github/HEAD) Simplify the test for swapped operand operations (#441)
		x   *   57e9e49 Merge pull request #437 from trundev/fix-pygae-426
		    |\  
		    | * 568087f CI: Suppress flake8 issue for swapped operand test
		    | * 5fb1081 CI: pytest for swapped operand operations
		    | * dcaa727 Non-commutative inner product support (pygae#426)
		x   * |   cc2590c Merge pull request #439 from trundev/drop-generated_jit
		    |\ \  
		    | |/  
		    |/|   
		    | * fc8657b Keep existing repr() results, with numpy>=2.0
		    | * c1860f0 Cleanup the @generated_jit leftovers (pygae#430)
		    | * d883824 Replace numba.generated_jit with njit (pygae#430)
		    | * e362d3e Apply suggestions from code review
		    | * 1679d9f CI: Update GitHub workflow
		    | * 8732307 CI: Fix "lint/Run flake8" step failure
		    |/  
		x   *   9e47ec2 Merge pull request #432 from fchapoton/typos1
		    |\  
		    | * eb59347 fix some typos and rst issues
		x   * |   6939f2a Merge pull request #435 from fchapoton/patch-1
		    |\ \  
		    | * | 8b24d76 fix doc error in _multivector.py
		    | |/  
		x   * |   3b5f83a Merge pull request #365 from kliment/master
		    |\ \  
		    | |/  
		    |/|   
		    | * e526291 Add pga2d module to predefined algebras list
		    | * 7b163ae Add 2D PGA (Cl(2,0,1))
		x   * 1102eba Rename *_gmt_matrix to *_mt_matrix for cases not specific to the geometric product (#419)
		x   * 8b1428c bug: fix compatibility with numba 0.55 (#420)
		x   * 3d7920e docs: fix transposition error in euler angles tutorial (#417)
		    * 0b6cffb ci: Fix pytest CI (#418)
		x   *   e63f856 Merge pull request #414 from eric-wieser/fix-numba-0.54.0
		    |\  
		    | * 13ac052 numba: fix overload_call on numba >= 0.54.0
		x   * | 9e8fcf2 Merge pull request #412 from eric-wieser/jit-la-inv
		    |\| 
		    | * 61e373e numba: add support for layout attributes and better constructors
		    | * 2ed5ea5 numba: add support for inverse functions
		    * | 116685e Syntax highlight
		    * | 497e235 Remove citation info from readme now that github has a better place for it.
		    * | 22d86bb Create CITATION.md
		    |/  
		    * a7a5407 Delete CITATION.cff
		    * c90be43 Try to fix the cff format
		    * ca89522 Try out the new github citation file
		    *   0801e24 Merge remote-tracking branch 'upstream/maintenance/1.4.x'
		    |\  
		    | * 6d3c9bd (github/maintenance/1.4.x) Fix notebook links in released docs
		    | * e4f5b69 Fix rST formatting errors in release notes
		    * 83f072c Fix yet another rST formatting error in release notes
		    * 99ffeae Fix another rST formatting error in release notes
		    * dea813a Fix rST formatting error in release notes
		    * d259d8e Bump version on master to start development on 1.5.0
		```
	    </details>